### PR TITLE
change all style prop to receive flattened styles

### DIFF
--- a/src/components/shared/Button/index.tsx
+++ b/src/components/shared/Button/index.tsx
@@ -3,6 +3,7 @@ import {
   Image,
   ImageSourcePropType,
   ImageStyle,
+  StyleProp,
   StyleSheet,
   Text,
   TextStyle,
@@ -49,11 +50,11 @@ interface Props {
   isLoading?: boolean;
   isDisabled?: boolean;
   onClick?: () => void;
-  style?: ViewStyle;
-  disabledStyle?: ViewStyle;
-  textStyle?: TextStyle;
+  style?: StyleProp<ViewStyle>;
+  disabledStyle?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
   imgLeftSrc?: ImageSourcePropType;
-  imgLeftStyle?: ImageStyle;
+  imgLeftStyle?: StyleProp<ImageStyle>;
   indicatorColor?: string;
   activeOpacity?: number;
   text?: string;

--- a/src/components/shared/ButtonGroup/index.tsx
+++ b/src/components/shared/ButtonGroup/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import {
+  StyleProp,
   Text,
   TextStyle,
   TouchableOpacity,
@@ -9,12 +10,12 @@ import {
 
 interface Props {
   testID?: string;
-  containerStyle?: ViewStyle;
-  style?: ViewStyle;
-  viewStyle?: ViewStyle;
-  selectedViewStyle?: ViewStyle;
-  textStyle?: TextStyle;
-  selectedTextStyle?: TextStyle;
+  containerStyle?: StyleProp<ViewStyle>;
+  style?: StyleProp<ViewStyle>;
+  viewStyle?: StyleProp<ViewStyle>;
+  selectedViewStyle?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
+  selectedTextStyle?: StyleProp<TextStyle>;
   data: string[];
   onPress?: (i: number) => void;
 }
@@ -25,10 +26,7 @@ function Shared(props: Props) {
   return (
     <View
       testID={props.testID}
-      style={{
-        ...props.containerStyle,
-        ...props.style,
-      }}
+      style={[props.containerStyle, props.style]}
     >
       {props.data.map((text, i) => {
         return (

--- a/src/components/shared/DropdownItem/index.tsx
+++ b/src/components/shared/DropdownItem/index.tsx
@@ -4,6 +4,7 @@ import {
   ImageSourcePropType,
   InteractionManager,
   LayoutChangeEvent,
+  StyleProp,
   StyleSheet,
   TouchableOpacity,
   View,
@@ -67,7 +68,7 @@ interface Props {
   visibleImage?: ImageSourcePropType | any;
   invisibleImage?: ImageSourcePropType | any;
   header: React.ReactElement;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
   children: React.ReactElement;
 }
 

--- a/src/components/shared/EditText/index.tsx
+++ b/src/components/shared/EditText/index.tsx
@@ -1,6 +1,7 @@
 import {
   NativeSyntheticEvent,
   Platform,
+  StyleProp,
   StyleSheet,
   Text,
   TextInput,
@@ -53,9 +54,9 @@ interface Props {
   parentTestID?: string;
   testID?: string;
   errorTestID?: string;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
   label?: string;
-  textStyle?: TextStyle;
+  textStyle?: StyleProp<TextStyle>;
   errorText?: string;
   text?: string;
   placeholder?: string;

--- a/src/components/shared/LoadingIndicator/index.tsx
+++ b/src/components/shared/LoadingIndicator/index.tsx
@@ -1,4 +1,4 @@
-import { ActivityIndicator, StyleSheet, View, ViewStyle } from 'react-native';
+import { ActivityIndicator, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 
 import React from 'react';
 
@@ -17,8 +17,8 @@ const styles = StyleSheet.create({
 });
 
 interface Props {
-  containerStyle?: ViewStyle;
-  style?: ViewStyle;
+  containerStyle?: StyleProp<ViewStyle>;
+  style?: StyleProp<ViewStyle>;
   color?: string;
   size?: number | 'small' | 'large';
 }

--- a/src/components/shared/SwitchToggle/index.tsx
+++ b/src/components/shared/SwitchToggle/index.tsx
@@ -1,5 +1,6 @@
 import {
   Animated,
+  StyleProp,
   StyleSheet,
   Text,
   TextStyle,
@@ -22,13 +23,13 @@ interface Props {
   buttonText?: string;
   backTextRight?: string;
   backTextLeft?: string;
-  buttonTextStyle?: TextStyle;
-  textRightStyle?: TextStyle;
-  textLeftStyle?: TextStyle;
-  buttonStyle?: ViewStyle;
-  buttonContainerStyle?: ViewStyle;
-  rightContainerStyle?: ViewStyle;
-  leftContainerStyle?: ViewStyle;
+  buttonTextStyle?: StyleProp<TextStyle>;
+  textRightStyle?: StyleProp<TextStyle>;
+  textLeftStyle?: StyleProp<TextStyle>;
+  buttonStyle?: StyleProp<ViewStyle>;
+  buttonContainerStyle?: StyleProp<ViewStyle>;
+  rightContainerStyle?: StyleProp<ViewStyle>;
+  leftContainerStyle?: StyleProp<ViewStyle>;
 }
 
 function SwitchToggle(props: Props) {

--- a/src/components/shared/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/shared/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -3,17 +3,20 @@
 exports[`[ButtonGroup] render renders without crashing 1`] = `
 <View
   style={
-    Object {
-      "alignItems": "center",
-      "alignSelf": "stretch",
-      "backgroundColor": "transparent",
-      "borderColor": "rgb(62,126,255)",
-      "borderWidth": 1,
-      "flexDirection": "row",
-      "height": 32,
-      "justifyContent": "center",
-      "marginTop": 24,
-    }
+    Array [
+      Object {
+        "alignItems": "center",
+        "alignSelf": "stretch",
+        "backgroundColor": "transparent",
+        "borderColor": "rgb(62,126,255)",
+        "borderWidth": 1,
+        "flexDirection": "row",
+        "height": 32,
+        "justifyContent": "center",
+        "marginTop": 24,
+      },
+      undefined,
+    ]
   }
 >
   <View


### PR DESCRIPTION
`Shared component`'s style interface has been changed using `StyleProp<T>` to receive flattened styles.
This change is necessary for the following:

```ts

      <Button
        style={[{
          marginVertical: 40,
        }, { margin: 10 }]}  // array style
        isDisabled={true}
        text='This is disabled!!'
        onClick={() => {}}
      />

```

`yarn test`
`yarn tsc`
`yarn lint`

All of the above scripts succeeded 🎉