### PR TITLE
Bump typescript minor version to 3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react-test-renderer": "16.9.0",
     "styled-components": "^4.4.1",
     "ts-jest": "^24.2.0",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.3"
   },
   "jest": {
     "preset": "react-native"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11508,10 +11508,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.6.4:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+typescript@^3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
## Description
I believe that the new features supported by typescript 3.7 such as [nullish coalescing](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing) and [optional chaining](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining) can improve code readability in this library.

For example in src/components/shared/Slider/Rail.tsx (currently on feat/slider branch), the following code
```
const railWidth = isNil(railStyleToApply.width) ? DEFAULT.width : railStyleToApply.width;
const markWidth = isNil(mark)
  ? isNil(markStyleToApply.width) ? DEFAULT.MARK.width : markStyleToApply.width : customMarkWidth as number;
```
can be simplified to
```
const railWidth = railStyleToApply.width ?? DEFAULT.width;
const markWidth = isNil(mark) ? markStyleToApply.width ?? DEFAULT.MARK.width : customMarkWidth;
```

Typescript 3.7 has four [breaking changes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#37-breaking-changes) but I have checked that they have no impact on dooboo-ui-native.
1. DOM Changes
  => these are changes in types for DOM API which are not used in dooboo-ui-native
2. Class Field Mitigations
  => typescript 3.7 documentation states `TypeScript 3.6 users will not be impacted, since that version was future-proofed for this feature`
3. Function Truthy Checks
  => If something related to this fails after upgrading to ts3.7, that probably should have been fixed from the beginning!
4. API changes
  => documentation states `the typeArguments property has been removed from the TypeReference interface` and I have checked that typeArguments was not used in our library

## Issues with current eslint config
Although typescript 3.7 itself will not affect the current codebase, the nullish coalescing syntax will not be acknowledged by eslint version currently in use. The eslint config for dooboo-ui-native currently comes from [@dooboo/eslint-config which uses typescript-eslint ^2.3.1](https://github.com/dooboolab/eslint-config/blob/master/package.json). Since typescript-eslint added support for parsing 3.7 features from [v2.4.0](https://github.com/typescript-eslint/typescript-eslint/releases), we must upgrade @dooboo/eslint-config before upgrading to typescript 3.7 in order to add eslint support!

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui-native/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
