### PR TITLE
[Feature][Branch][Slider] Modify `step` prop and Add `defaultTheme` of [Rail].

### DIFF
--- a/src/components/shared/Slider/Rail.tsx
+++ b/src/components/shared/Slider/Rail.tsx
@@ -10,6 +10,13 @@ interface MarkThemeType {
   backgroundColor: string;
 }
 
+type DefaultThemeNameType = 'lightblue' | 'dark' | 'blue' | undefined;
+type DefaultThemeType = {
+  LIGHTBLUE: 'lightblue';
+  DARK: 'dark';
+  BLUE: 'blue';
+};
+
 interface ThemeType extends DefaultTheme {
   backgroundColor: string;
   markColor: string;
@@ -45,9 +52,7 @@ interface Props {
   markCount?: number;
   startMark?: boolean;
   endMark?: boolean;
-  dark?: boolean;
-  lightblue?: boolean;
-  blue?: boolean;
+  defaultTheme?: 'lightblue' | 'dark' | 'blue';
   inverted?: boolean;
   disabled?: boolean;
   fit?: boolean;
@@ -79,11 +84,19 @@ const DEFAULT = {
   },
 };
 
+export const DEFAULT_THEME: DefaultThemeType = {
+  LIGHTBLUE: 'lightblue',
+  DARK: 'dark',
+  BLUE: 'blue',
+};
+
 export const THEME: {
+  NAME: DefaultThemeType;
   LIGHTBLUE: StatefulThemeType;
   DARK: StatefulThemeType;
   BLUE: StatefulThemeType;
 } = {
+  NAME: DEFAULT_THEME,
   LIGHTBLUE: {
     backgroundColor: COLOR.LIGHTBLUE1,
     markColor: COLOR.LIGHTBLUE2,
@@ -168,15 +181,11 @@ const getStatefulTheme = ({
 };
 
 const getDefaultTheme = ({
-  dark,
-  lightblue,
-  blue,
+  defaultTheme,
   inverted,
   disabled,
 }: {
-  dark?: boolean;
-  lightblue?: boolean;
-  blue?: boolean;
+  defaultTheme?: DefaultThemeNameType;
   inverted?: boolean;
   disabled?: boolean;
 }): ThemeType => {
@@ -185,21 +194,21 @@ const getDefaultTheme = ({
     disabled,
   };
 
-  if (dark) {
+  if (defaultTheme === THEME.NAME.DARK) {
     return getStatefulTheme({
       theme: THEME.DARK,
       ...statefulThemeOptions,
     });
   }
 
-  if (lightblue) {
+  if (defaultTheme === THEME.NAME.LIGHTBLUE) {
     return getStatefulTheme({
       theme: THEME.LIGHTBLUE,
       ...statefulThemeOptions,
     });
   }
 
-  if (blue) {
+  if (defaultTheme === THEME.NAME.BLUE) {
     return getStatefulTheme({
       theme: THEME.BLUE,
       ...statefulThemeOptions,
@@ -459,9 +468,7 @@ const Rail: FC<Props> = ({
   markCount,
   startMark = true,
   endMark = true,
-  dark,
-  lightblue,
-  blue,
+  defaultTheme,
   inverted = false,
   disabled = false,
   onInit,
@@ -480,20 +487,18 @@ const Rail: FC<Props> = ({
   const railStyleToApply = StyleSheet.flatten(style);
   const markStyleToApply = StyleSheet.flatten(markStyle);
 
-  const defaultTheme = getDefaultTheme({
-    dark,
-    lightblue,
-    blue,
+  const defaultThemeToApply = getDefaultTheme({
+    defaultTheme,
     inverted,
     disabled,
   });
 
   const railThemeToApply: RailThemeType = {
-    backgroundColor: railStyleToApply.backgroundColor || defaultTheme.backgroundColor,
+    backgroundColor: railStyleToApply.backgroundColor || defaultThemeToApply.backgroundColor,
   };
 
   const markThemeToApply: MarkThemeType = {
-    backgroundColor: markStyleToApply.backgroundColor || defaultTheme.markColor,
+    backgroundColor: markStyleToApply.backgroundColor || defaultThemeToApply.markColor,
   };
 
   const railWidth = getRailWidth(railStyleToApply);

--- a/src/components/shared/Slider/Rail.tsx
+++ b/src/components/shared/Slider/Rail.tsx
@@ -454,8 +454,8 @@ const Rail: FC<Props> = ({
   mark,
   customMarkWidth,
   hideMark = false,
-  step = 1,
-  pixelsPerStep = 20,
+  step = 20,
+  pixelsPerStep,
   markCount,
   startMark = true,
   endMark = true,
@@ -499,7 +499,7 @@ const Rail: FC<Props> = ({
   const railWidth = getRailWidth(railStyleToApply);
   const markWidth = isNil(mark) ? getMarkWidth(markStyleToApply) : customMarkWidth as number;
 
-  const stepByPixel = step * pixelsPerStep;
+  const stepByPixel = isNil(pixelsPerStep) ? step : step * (pixelsPerStep as number);
   const markOptions = {
     railWidth,
     markWidth,

--- a/src/components/shared/Slider/index.tsx
+++ b/src/components/shared/Slider/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useRef, useState } from 'react';
 import { getPercent, percentToValue, valueToPercent } from './utils';
+
 import { PanResponder } from 'react-native';
 import Rail from './Rail';
 import Thumb from './Thumb';


### PR DESCRIPTION
## Description

I modified some features reviewed by @YongPilMoon in https://github.com/dooboolab/dooboo-ui-native/pull/65. Thank you so much!

- Use only `step` prop to locate marks for default.
  - If `pixelsForStep` or `markCount` are specified, marks are created as the values.
- Add `defaultTheme` prop to change the default theme instead of `dark`, `lightblue` and `blue` props.
  - The values are `dark`, `lightblue` and `blue`.

## Related Issues

#41 #47 

## Tests

- No tests.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui-native/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
