### PR TITLE
[Enhancement] Upgrade circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,13 @@
-version: 2
+version: 2.1
+orbs:
+  codecov: codecov/codecov@1.0.5
 jobs:
   node:
     working_directory: ~/dooboo
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
+        environment:
+          TZ: "Asia/Seoul"
     steps:
       - checkout
 
@@ -56,11 +60,9 @@ jobs:
           environment:
             JEST_JUNIT_OUTPUT: test-results/jest/junit.xml
 
-      - run:
-          name: Coverage
-          working_directory: .
-          command: |
-            yarn codecov -t 5bf93db3-06d5-4644-8188-f9de5067953d
+      - codecov/upload:
+          file: ./coverage/lcov.info
+          token: a2824baa-7d04-4204-9665-7c99c1204f30
 
       - store_test_results:
           path: coverage
@@ -96,18 +98,6 @@ jobs:
           key: node-v3-{{ checksum "package.json" }}-{{ arch }}
           paths:
             - node_modules
-
-      # - restore_cache:
-      #     key: bundle-v1-{{ checksum "android/Gemfile.lock" }}-{{ arch }}
-
-      # - run:
-      #     command: bundle install --path vendor/bundle
-      #     working_directory: android
-
-      # - save_cache:
-      #     key: bundle-v1-{{ checksum "android/Gemfile.lock" }}-{{ arch }}
-      #     paths:
-      #       - android/vendor/bundle
 
       - run:
           name: Check MD5 on files


### PR DESCRIPTION
## Description

Bump up circleci version to `2.1` and add `orbs` for `codecov`. Also, set the timezone to `Asia/Seoul`.

## Related Issues
`codecov` upload is not the right way to config currently since it exposes token in config. Also, setting timezone will help snapshot test failing when using the `Date` class.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui-native/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
