### PR TITLE
[Feature][Branch][Snackbar] Consecutive snackbars

### DIFF
--- a/src/components/shared/Snackbar/index.tsx
+++ b/src/components/shared/Snackbar/index.tsx
@@ -98,16 +98,16 @@ const Snackbar: React.FC<SnackbarProps> = React.forwardRef<SnackbarRef, Snackbar
     <>
       {showingState.isVisible && (
         <Container testID={testID} style={containerStyle}>
-        <Text style={messageStyle}>{text}</Text>
-        {actionText && (
-          <ActionContainer>
-            <Touchable onPress={onPressAction}>
-              <ActionButton>
-                <Text style={actionStyle}>{actionText}</Text>
-              </ActionButton>
-            </Touchable>
-          </ActionContainer>
-        )}
+          <Text style={messageStyle}>{text}</Text>
+          {actionText && (
+            <ActionContainer>
+              <Touchable onPress={onPressAction}>
+                <ActionButton>
+                  <Text style={actionStyle}>{actionText}</Text>
+                </ActionButton>
+              </Touchable>
+            </ActionContainer>
+          )}
         </Container>
       )}
     </>

--- a/src/components/shared/Snackbar/index.tsx
+++ b/src/components/shared/Snackbar/index.tsx
@@ -1,27 +1,30 @@
 import * as React from 'react';
 
-import { Dimensions, Text, TextStyle, ViewStyle } from 'react-native';
+import { Animated, Dimensions, StyleSheet, Text, TextStyle, ViewStyle } from 'react-native';
 
 import styled from 'styled-components/native';
 
 const { width } = Dimensions.get('screen');
 const maxWidth = width - 32;
 
-const Container = styled.View`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  min-width: 150px;
-  max-width: ${maxWidth};
-  text-align: left;
-  align-items: center;
-  position: absolute;
-  font-size: 16;
-  padding: 10px 16px;
-  bottom: 50px;
-  background-color: #303235;
-  border-radius: 10;
-`;
+const styles = StyleSheet.create({
+  container: {
+    display: 'flex',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    minWidth: 150,
+    maxWidth,
+    textAlign: 'left',
+    alignItems: 'center',
+    position: 'absolute',
+    fontSize: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    bottom: 50,
+    backgroundColor: '#303235',
+    borderRadius: 10,
+  },
+});
 
 const ActionContainer = styled.View`
   display: flex;
@@ -73,21 +76,36 @@ const Snackbar: React.FC<SnackbarProps> = React.forwardRef<SnackbarRef, Snackbar
   const [content, setContent] = React.useState<Content>({ text: '', timer: Timer.SHORT });
   const { text, actionText, messageStyle, actionStyle, containerStyle, timer = Timer.SHORT, onPressAction } = content;
   const { isShowing, isVisible, timeout } = showingState;
+  const [fadeAnim] = React.useState(new Animated.Value(0));
   const show = (content): void => {
     setContent(content);
     clearTimeout(timeout);
     setShowingState({ isShowing: true });
   };
+  const close = (): void => {
+    Animated.timing(
+      fadeAnim,
+      {
+        toValue: 0,
+        duration: 200,
+      },
+    ).start(() => setShowingState({ isVisible: false }));
+  };
   React.useEffect(() => {
     if (isShowing) {
       if (isVisible) {
-        setShowingState({ isVisible: false });
+        close();
       } else {
         const timeout = setTimeout(() => {
-          setShowingState({ isVisible: false });
+          close();
         }, timer);
-
-        setShowingState({ isShowing: false, isVisible: true, timeout });
+        Animated.timing(
+          fadeAnim,
+          {
+            toValue: 1,
+            duration: 200,
+          },
+        ).start(() => setShowingState({ isShowing: false, isVisible: true, timeout }));
       }
     }
   }, [showingState]);
@@ -97,7 +115,7 @@ const Snackbar: React.FC<SnackbarProps> = React.forwardRef<SnackbarRef, Snackbar
   return (
     <>
       {showingState.isVisible && (
-        <Container testID={testID} style={containerStyle}>
+        <Animated.View testID={testID} style={[styles.container, containerStyle, { opacity: fadeAnim }]}>
           <Text style={messageStyle}>{text}</Text>
           {actionText && (
             <ActionContainer>
@@ -108,7 +126,7 @@ const Snackbar: React.FC<SnackbarProps> = React.forwardRef<SnackbarRef, Snackbar
               </Touchable>
             </ActionContainer>
           )}
-        </Container>
+        </Animated.View>
       )}
     </>
   );

--- a/src/components/shared/__tests__/Snackbar.test.tsx
+++ b/src/components/shared/__tests__/Snackbar.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-import Snackbar, { SnackbarProps, SnackbarRef } from '../Snackbar';
+import Snackbar, { SnackbarRef } from '../Snackbar';
 import { Text, TouchableOpacity, View } from 'react-native';
 
-import { render, waitForElement, fireEvent } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import renderer, { act } from 'react-test-renderer';
 
 // Note: test renderer must be required after react-native.

--- a/src/components/shared/__tests__/Snackbar.test.tsx
+++ b/src/components/shared/__tests__/Snackbar.test.tsx
@@ -1,41 +1,47 @@
-import 'react-native';
-
 import * as React from 'react';
 
-import Snackbar, { SnackbarProps } from '../Snackbar';
+import Snackbar, { SnackbarProps, SnackbarRef } from '../Snackbar';
+import { Text, TouchableOpacity, View } from 'react-native';
 
-import { render } from '@testing-library/react-native';
-import renderer from 'react-test-renderer';
+import { render, waitForElement, fireEvent } from '@testing-library/react-native';
+import renderer, { act } from 'react-test-renderer';
 
 // Note: test renderer must be required after react-native.
-
-const props: SnackbarProps = {
-  testID: 'snackbar',
-  text: 'SnackBar!',
-  show: true,
-  setShow: jest.fn(),
-};
-let component: React.ReactElement;
+let snackbarRef: React.MutableRefObject<SnackbarRef>;
 
 jest.useFakeTimers();
 
+function TestWrapper(): React.ReactElement {
+  snackbarRef = React.useRef();
+  return (
+    <View style={{ flex: 1 }}>
+      <TouchableOpacity
+        testID="Button"
+        onPress={(): void => snackbarRef.current && snackbarRef.current.show({
+          text: 'snackbar content',
+        })}>
+        <Text>
+          show snack bar
+        </Text>
+      </TouchableOpacity>
+      <Snackbar ref={snackbarRef} />
+    </View>
+  );
+}
+
 describe('[Snackbar]', () => {
-  beforeEach(() => {
-    component = <Snackbar {...props} />;
-  });
-
-  it('renders without crashing', () => {
-    const rendered = renderer.create(component);
+  it('renders TestWrapper without crashing', () => {
+    const rendered = renderer.create(<TestWrapper />);
     expect(rendered.toJSON()).toMatchSnapshot();
-    expect(rendered.toJSON()).toBeTruthy();
-
-    rendered.update(<Snackbar {...{ ...props, show: false }} />);
-    expect(rendered.toJSON()).toBeFalsy();
   });
 
-  it('should dismiss after timeout', async () => {
-    render(component);
+  it('should simulate showing snackbar', async () => {
+    const renderResult = render(<TestWrapper />);
+    const btn = renderResult.getByTestId('Button');
+    act(() => {
+      fireEvent.press(btn);
+      fireEvent.press(btn);
+    });
     jest.runAllTimers();
-    expect(props.setShow).toBeCalled();
   });
 });

--- a/src/components/shared/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/shared/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -1,33 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`[Snackbar] renders without crashing 1`] = `
+exports[`[Snackbar] renders TestWrapper without crashing 1`] = `
 <View
   style={
-    Array [
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "#303235",
-        "borderRadius": 10,
-        "bottom": 50,
-        "display": "flex",
-        "flexDirection": "row",
-        "flexWrap": "wrap",
-        "fontSize": 16,
-        "maxWidth": 718,
-        "minWidth": 150,
-        "paddingBottom": 10,
-        "paddingLeft": 16,
-        "paddingRight": 16,
-        "paddingTop": 10,
-        "position": "absolute",
-        "textAlign": "left",
-      },
-    ]
+    Object {
+      "flex": 1,
+    }
   }
-  testID="snackbar"
 >
-  <Text>
-    SnackBar!
-  </Text>
+  <View
+    accessible={true}
+    focusable={true}
+    isTVSelectable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+    testID="Button"
+  >
+    <Text>
+      show snack bar
+    </Text>
+  </View>
 </View>
 `;

--- a/storybook/stories/Snackbar.stories.tsx
+++ b/storybook/stories/Snackbar.stories.tsx
@@ -1,10 +1,10 @@
+import { Alert, Text } from 'react-native';
 import React, { useCallback, useRef, useState } from 'react';
 import Snackbar, { SnackbarRef, Timer } from '../../src/components/shared/Snackbar';
 import { color, text } from '@storybook/addon-knobs';
 
 import { ContainerDeco } from '../decorators';
 import SwitchToggle from '../../src/components/shared/SwitchToggle';
-import { Text, Alert } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
 import styled from 'styled-components/native';
 
@@ -42,6 +42,7 @@ const Button = styled.TouchableOpacity`
 `;
 
 function Default(): React.ReactElement {
+  const snackbar = useRef<SnackbarRef>();
   const [shortOrLong, setShortOrLong] = useState<boolean>(false);
   const [longText, setLongText] = useState<boolean>(false);
   const snackbarText = text('Snackbar Text', 'Simple Snackbar is opened');
@@ -61,11 +62,9 @@ function Default(): React.ReactElement {
       messageStyle: {
         color: messageColor,
         fontSize: 17,
-      }
-    })
+      },
+    });
   }, [shortOrLong, longText, containerColor, messageColor]);
-
-  const snackbar = useRef<SnackbarRef>();
 
   return (
     <Container>
@@ -94,6 +93,7 @@ function Default(): React.ReactElement {
 }
 
 function WithAction(): React.ReactElement {
+  const snackbar = useRef<SnackbarRef>();
   const [shortOrLong, setShortOrLong] = useState<boolean>(false);
   const [longText, setLongText] = useState<boolean>(false);
   const snackbarText = text('Snackbar Text', 'Simple Snackbar is opened');
@@ -125,10 +125,8 @@ function WithAction(): React.ReactElement {
         fontSize: 17,
       },
       onPressAction,
-    })
+    });
   }, [shortOrLong, longText, containerColor, messageColor]);
-
-  const snackbar = useRef<SnackbarRef>();
 
   return (
     <Container>

--- a/storybook/stories/Snackbar.stories.tsx
+++ b/storybook/stories/Snackbar.stories.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useState } from 'react';
-import Snackbar, { Timer } from '../../src/components/shared/Snackbar';
+import React, { useCallback, useRef, useState } from 'react';
+import Snackbar, { SnackbarRef, Timer } from '../../src/components/shared/Snackbar';
 import { color, text } from '@storybook/addon-knobs';
 
 import { ContainerDeco } from '../decorators';
 import SwitchToggle from '../../src/components/shared/SwitchToggle';
-import { Text } from 'react-native';
+import { Text, Alert } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
 import styled from 'styled-components/native';
 
@@ -42,8 +42,6 @@ const Button = styled.TouchableOpacity`
 `;
 
 function Default(): React.ReactElement {
-  const [show, setShow] = useState<boolean>(false);
-  const [timer, setTimer] = useState<Timer>(Timer.SHORT);
   const [shortOrLong, setShortOrLong] = useState<boolean>(false);
   const [longText, setLongText] = useState<boolean>(false);
   const snackbarText = text('Snackbar Text', 'Simple Snackbar is opened');
@@ -54,9 +52,20 @@ function Default(): React.ReactElement {
   const containerColor = color('container color', '#1976D1');
   const messageColor = color('message color', '#ffffff');
   const onPress = useCallback((): void => {
-    setShow(true);
-    shortOrLong ? setTimer(Timer.LONG) : setTimer(Timer.SHORT);
-  }, [shortOrLong]);
+    snackbar.current && snackbar.current.show({
+      text: longText ? snackbarLongText : snackbarText,
+      timer: shortOrLong ? Timer.LONG : Timer.SHORT,
+      containerStyle: {
+        backgroundColor: containerColor,
+      },
+      messageStyle: {
+        color: messageColor,
+        fontSize: 17,
+      }
+    })
+  }, [shortOrLong, longText, containerColor, messageColor]);
+
+  const snackbar = useRef<SnackbarRef>();
 
   return (
     <Container>
@@ -79,26 +88,12 @@ function Default(): React.ReactElement {
       <Button onPress={onPress}>
         <Text style={{ textAlign: 'center' }}>OPEN SNACKBAR(Default)</Text>
       </Button>
-      <Snackbar
-        text={longText ? snackbarLongText : snackbarText}
-        show={show}
-        setShow={setShow}
-        timer={timer}
-        containerStyle={{
-          backgroundColor: containerColor,
-        }}
-        messageStyle={{
-          color: messageColor,
-          fontSize: 17,
-        }}
-      />
+      <Snackbar ref={snackbar}/>
     </Container>
   );
 }
 
 function WithAction(): React.ReactElement {
-  const [show, setShow] = useState<boolean>(false);
-  const [timer, setTimer] = useState<Timer>(Timer.SHORT);
   const [shortOrLong, setShortOrLong] = useState<boolean>(false);
   const [longText, setLongText] = useState<boolean>(false);
   const snackbarText = text('Snackbar Text', 'Simple Snackbar is opened');
@@ -106,17 +101,34 @@ function WithAction(): React.ReactElement {
     'Snackbar Long Text',
     'Lorem ipsum dolor, sit amet consectetur adipisicing elit. Minus quia vel maxime nost',
   );
-  const actionText = text('action text', 'close');
+  const actionText = text('action text', 'Action');
   const containerColor = color('container color', '#2979ff');
   const messageColor = color('message color', '#ffffff');
   const actionColor = color('action color', '#000000');
   const onPressAction = useCallback((): void => {
-    setShow(false);
+    Alert.alert('Action!!');
   }, []);
   const onPress = useCallback((): void => {
-    setShow(true);
-    shortOrLong ? setTimer(Timer.LONG) : setTimer(Timer.SHORT);
-  }, [shortOrLong]);
+    snackbar.current && snackbar.current.show({
+      text: longText ? snackbarLongText : snackbarText,
+      timer: shortOrLong ? Timer.LONG : Timer.SHORT,
+      containerStyle: {
+        backgroundColor: containerColor,
+      },
+      messageStyle: {
+        color: messageColor,
+        fontSize: 17,
+      },
+      actionText,
+      actionStyle: {
+        color: actionColor,
+        fontSize: 17,
+      },
+      onPressAction,
+    })
+  }, [shortOrLong, longText, containerColor, messageColor]);
+
+  const snackbar = useRef<SnackbarRef>();
 
   return (
     <Container>
@@ -140,23 +152,7 @@ function WithAction(): React.ReactElement {
         <Text style={{ textAlign: 'center' }}>OPEN SNACKBAR(With Action)</Text>
       </Button>
       <Snackbar
-        text={longText ? snackbarLongText : snackbarText}
-        actionText={actionText}
-        show={show}
-        setShow={setShow}
-        timer={timer}
-        onPressAction={onPressAction}
-        actionStyle={{
-          color: actionColor,
-          fontSize: 17,
-        }}
-        containerStyle={{
-          backgroundColor: containerColor,
-        }}
-        messageStyle={{
-          color: messageColor,
-          fontSize: 17,
-        }}
+        ref={snackbar}
       />
     </Container>
   );


### PR DESCRIPTION
## Description

I modified the way of showing `snackbar`.
A snack bar has a `show` function and will be appeared when the function is called. 
If the function called when the previous one is showing, then the previous one will be dismissed immediately and the next one will appear after that. 

![Jan-08-2020 00-36-57](https://user-images.githubusercontent.com/17980230/71907357-30717080-31af-11ea-8e13-bea94e91a622.gif)

## Related Issues

#46 

## Tests

I added the following tests:

- simulating show function called. 

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui-native/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
