### PR TITLE
[Feature][EditText] Add props focusedLabelStyle, focusedBorderWidth

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,5 +3,6 @@ module.exports = {
   extends: '@dooboo/eslint-config',
   rules: {
     '@typescript-eslint/no-empty-function': 0,
+    '@typescript-eslint/ban-ts-ignore': 0,
   },
 };

--- a/src/components/shared/EditText/README.md
+++ b/src/components/shared/EditText/README.md
@@ -14,34 +14,38 @@
 
 ## Props
 
-|                      | necessary | types                  | default      |
-| -------------------- | --------- | ---------------------- | ------------ |
-| testID               |           | string                 |              |
-| errorTestID          |           | string                 |              |
-| isRow                |           | boolean                |    `false`   |
-| style                |           | `StyleProp<ViewStyle>` |              |
-| label                |           | string                 |              |
-| labelTextStyle       |           | `StyleProp<TextStyle>` |              |
-| value                |           | `TextInputProps`       |              |
-| inputContainerType   |           | string                 | `underlined` |
-| inputContainerRadius |           | string                 |      `3`     |
-| borderStyle          |           | `StyleProp<ViewStyle>` |              |
-| borderWidth          |           | number                 |     `0.6`    |
-| borderColor          |           | string                 |   `#eaeaf9`  |
-| inputLeftMargin      |           | number                 |     `110`    |
-| textStyle            |           | `StyleProp<TextStyle>` |              |
-| placeholder          |           | string                 |              |
-| placeholderTextColor |           | string                 |              |
-| secureTextEntry      |           | boolean                |              |
-| onChangeText         |           | (e) => {}              |              |
-| onSubmitEditing      |           | func                   |              |
-| leftElement          |           | `ReactElement`         |              |
-| leftElementStyle     |           | `StyleProp<ViewStyle>` |              |
-| rightElement         |           | `ReactElement`         |              |
-| rightElementStyle    |           | `StyleProp<ViewStyle>` |              |
-| textInputProps       |           | `TextInputProps`       |              |
-| errorText            |           | string                 |              |
-| errorTextStyle       |           | `StyleProp<TextStyle>` |              |
+|                      | necessary | types                  | default              |
+| -------------------- | --------- | ---------------------- | -------------------- |
+| testID               |           | string                 |                      |
+| errorTestID          |           | string                 |                      |
+| isRow                |           | boolean                |        `false`       |
+| style                |           | `ViewStyle`            |                      |
+| label                |           | string                 |                      |
+| labelTextStyle       |           | `TextStyle`            |                      |
+| value                |           | `TextInputProps`       |                      |
+| inputContainerType   |           | string                 |     `underlined`     |
+| inputContainerRadius |           | string                 |          `3`         |
+| borderStyle          |           | `ViewStyle`            |                      |
+| borderWidth          |           | number                 |         `0.6`        |
+| borderColor          |           | string                 |       `#eaeaf9`      |
+| inputLeftMargin      |           | number                 |         `110`        |
+| textStyle            |           | `TextStyle`            |                      |
+| placeholder          |           | string                 |                      |
+| placeholderTextColor |           | string                 |                      |
+| secureTextEntry      |           | boolean                |                      |
+| onChangeText         |           | (e) => {}              |                      |
+| onSubmitEditing      |           | func                   |                      |
+| leftElement          |           | `ReactElement`         |                      |
+| leftElementStyle     |           | `ViewStyle`            |                      |
+| rightElement         |           | `ReactElement`         |                      |
+| rightElementStyle    |           | `ViewStyle`            |                      |
+| textInputProps       |           | `TextInputProps`       |                      |
+| focusedLabelStyle    |           | `TextStyle`            | `fontWeight: 'bold'` |
+| focusedBorderWidth   |           | number                 |          `1`         | 
+| focusColor           |           | string                 |       `#79B3F5`      |
+| errorColor           |           | string                 |       `#FF8989`      |
+| errorText            |           | string                 |                      |
+| errorTextStyle       |           | `TextStyle`            |                      |
 
 ## Installation
 

--- a/src/components/shared/EditText/index.tsx
+++ b/src/components/shared/EditText/index.tsx
@@ -135,6 +135,8 @@ interface Props {
   leftElementStyle?: ViewStyle;
   rightElement?: ReactElement;
   rightElementStyle?: ViewStyle;
+  focusedLabelStyle?: TextStyle;
+  focusedBorderWidth?: number;
   focusColor?: string;
   errorColor?: string;
   autoCapitalize?: TextInputProps['autoCapitalize'];
@@ -181,6 +183,8 @@ function EditText(props: Props): ReactElement {
     leftElementStyle,
     rightElement,
     rightElementStyle,
+    focusedLabelStyle = { fontWeight: 'bold' },
+    focusedBorderWidth = 1,
     focusColor = '#79B3F5',
     errorColor = '#FF8989',
     autoCapitalize = 'none',
@@ -199,27 +203,27 @@ function EditText(props: Props): ReactElement {
       return (
         <Container style={style}>
           <StyledLabel
+            // @ts-ignore
             style={[
-              focused
-                ? { color: focusColor }
-                : errorText
-                  ? { color: errorColor }
-                  : null,
               labelTextStyle,
+              errorText
+                ? { color: errorColor }
+                : focused
+                  ? [{ color: focusColor }, focusedLabelStyle]
+                  : null,
             ]}>
             {label}
           </StyledLabel>
           <StyledContent>
             <StyledLine
               style={[
-                { borderColor: borderColor },
-                focused
-                  ? { borderColor: focusColor }
-                  : errorText
-                    ? { borderColor: errorColor }
-                    : null,
-                { borderBottomWidth: borderWidth },
+                { borderBottomWidth: borderWidth, borderColor: borderColor },
                 borderStyle,
+                errorText
+                  ? { borderColor: errorColor }
+                  : focused
+                    ? [{ borderColor: focusColor }, { borderBottomWidth: focusedBorderWidth }]
+                    : null,
               ]}
             >
               <StyledTextInput
@@ -258,26 +262,26 @@ function EditText(props: Props): ReactElement {
         <StyledRowContainer style={style}>
           <StyledRowContent
             style={[
-              { borderColor: borderColor },
-              focused
-                ? { borderColor: focusColor }
-                : errorText
-                  ? { borderColor: errorColor }
-                  : null,
-              { borderBottomWidth: borderWidth },
+              { borderColor: borderColor, borderBottomWidth: borderWidth },
               borderStyle,
+              errorText
+                ? { borderColor: errorColor, borderBottomWidth: focusedBorderWidth }
+                : focused
+                  ? { borderColor: focusColor, borderBottomWidth: focusedBorderWidth }
+                  : null,
             ]}
           >
             {label ? (
               <StyledRowLabel
+                // @ts-ignore
                 style={[
+                  labelTextStyle,
                   errorText
-                    ? { color: errorColor }
+                    ? [{ color: errorColor }, focusedLabelStyle]
                     : focused
-                      ? { color: focusColor }
+                      ? [{ color: focusColor }, focusedLabelStyle]
                       : null,
                   { width: labelWidth },
-                  labelTextStyle,
                 ]}>
                 {label}
               </StyledRowLabel>
@@ -324,33 +328,33 @@ function EditText(props: Props): ReactElement {
       return (
         <Container style={style}>
           <StyledLabel
+            // @ts-ignore
             style={[
-              focused
-                ? { color: focusColor }
-                : errorText
-                  ? { color: errorColor }
-                  : null,
               labelTextStyle,
+              errorText
+                ? { color: errorColor }
+                : focused
+                  ? [{ color: focusColor }, focusedLabelStyle]
+                  : null,
             ]}>
             {label}
           </StyledLabel>
           <StyledContent>
             <StyledLine
               style={[
-                { borderColor: borderColor },
-                focused
-                  ? { borderColor: focusColor }
-                  : errorText
-                    ? { borderColor: errorColor }
+                { borderWidth: borderWidth, borderRadius: inputContainerRadius, borderColor: borderColor },
+                borderStyle,
+                errorText
+                  ? { borderColor: errorColor }
+                  : focused
+                    ? [{ borderColor: focusColor }, { borderWidth: focusedBorderWidth }]
                     : null,
-                { borderWidth: borderWidth, borderRadius: inputContainerRadius },
                 !leftElement
                   ? { paddingLeft: 15 }
                   : null,
                 !rightElement
                   ? { paddingRight: 15 }
                   : null,
-                borderStyle,
               ]}
             >
               {
@@ -407,24 +411,25 @@ function EditText(props: Props): ReactElement {
           <StyledRowContent
             style={[
               { borderWidth: borderWidth, borderRadius: inputContainerRadius, borderColor: borderColor },
-              focused
-                ? { borderColor: focusColor }
-                : errorText
-                  ? { borderColor: errorColor }
-                  : null,
               borderStyle,
+              errorText
+                ? { borderColor: errorColor, borderWidth: focusedBorderWidth }
+                : focused
+                  ? { borderColor: focusColor, borderWidth: focusedBorderWidth }
+                  : null,
             ]}
           >
             {label ? (
               <StyledRowLabel
+                // @ts-ignore
                 style={[
+                  labelTextStyle,
                   errorText
-                    ? { color: errorColor }
+                    ? [{ color: errorColor }, focusedLabelStyle]
                     : focused
-                      ? { color: focusColor }
+                      ? [{ color: focusColor }, focusedLabelStyle]
                       : null,
                   { marginLeft: 15, width: labelWidth },
-                  labelTextStyle,
                 ]}>
                 {label}
               </StyledRowLabel>

--- a/src/components/shared/__tests__/EditText.test.tsx
+++ b/src/components/shared/__tests__/EditText.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import {
   RenderResult,
-  act,
   fireEvent,
   render,
   wait,
@@ -41,6 +40,9 @@ describe('[EditText]', () => {
       leftElementStyle: {},
       focusColor: '#fff',
       inputContainerRadius: 30,
+      onFocus: undefined,
+      focusLabelStyle: { fontWeight: 500 },
+      focusBorderWidth: 10,
     };
 
     beforeEach(() => {
@@ -50,11 +52,9 @@ describe('[EditText]', () => {
 
     it('should set error message when no valid email has been written', async () => {
       const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
-      act(() => {
+      await wait(() => {
         fireEvent.changeText(input, 'input test');
       });
-
-      act(() => wait());
 
       expect(value).toEqual('input test');
     });
@@ -62,8 +62,19 @@ describe('[EditText]', () => {
     it('should trigger onSubmit', async () => {
       const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-      act(() => {
+      await wait(() => {
         fireEvent.submitEditing(input);
+      });
+    });
+
+    it('renders editText and running onFocus', async () => {
+      props.onFocus = (): void => {};
+      component = <EditText {...props} />;
+      testingLib = render(component);
+      const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
+
+      await wait(() => {
+        fireEvent.focus(input);
       });
     });
   });
@@ -93,7 +104,7 @@ describe('[EditText]', () => {
       testingLib = render(component);
       const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-      act(() => {
+      await wait(() => {
         fireEvent.focus(input);
       });
     });
@@ -106,7 +117,7 @@ describe('[EditText]', () => {
         testingLib = render(component);
         const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-        act(() => {
+        await wait(() => {
           fireEvent.blur(input);
         });
       });
@@ -117,7 +128,7 @@ describe('[EditText]', () => {
         testingLib = render(component);
         const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-        act(() => {
+        await wait(() => {
           fireEvent.blur(input);
         });
       });
@@ -150,7 +161,7 @@ describe('[EditText]', () => {
       testingLib = render(component);
       const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-      act(() => {
+      await wait(() => {
         fireEvent.focus(input);
       });
     });
@@ -164,7 +175,7 @@ describe('[EditText]', () => {
         testingLib = render(component);
         const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-        act(() => {
+        await wait(() => {
           fireEvent.blur(input);
         });
       });
@@ -175,7 +186,7 @@ describe('[EditText]', () => {
         testingLib = render(component);
         const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-        act(() => {
+        await wait(() => {
           fireEvent.blur(input);
         });
       });
@@ -187,11 +198,11 @@ describe('[EditText]', () => {
         testingLib = render(component);
         const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-        act(() => {
+        await wait(() => {
           fireEvent.blur(input);
         });
 
-        act(() => {
+        await wait(() => {
           fireEvent.focus(input);
         });
       });
@@ -223,7 +234,7 @@ describe('[EditText]', () => {
       testingLib = render(component);
       const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-      act(() => {
+      await wait(() => {
         fireEvent.focus(input);
       });
     });
@@ -236,7 +247,7 @@ describe('[EditText]', () => {
         testingLib = render(component);
         const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-        act(() => {
+        await wait(() => {
           fireEvent.blur(input);
         });
       });
@@ -247,7 +258,7 @@ describe('[EditText]', () => {
         testingLib = render(component);
         const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-        act(() => {
+        await wait(() => {
           fireEvent.blur(input);
         });
       });
@@ -280,7 +291,7 @@ describe('[EditText]', () => {
       testingLib = render(component);
       const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-      act(() => {
+      await wait(() => {
         fireEvent.focus(input);
       });
     });
@@ -294,7 +305,7 @@ describe('[EditText]', () => {
         testingLib = render(component);
         const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-        act(() => {
+        await wait(() => {
           fireEvent.blur(input);
         });
       });
@@ -305,7 +316,7 @@ describe('[EditText]', () => {
         testingLib = render(component);
         const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-        act(() => {
+        await wait(() => {
           fireEvent.blur(input);
         });
       });
@@ -317,11 +328,11 @@ describe('[EditText]', () => {
         testingLib = render(component);
         const input = await waitForElement(() => testingLib.getByTestId('INPUT_TEST'));
 
-        act(() => {
+        await wait(() => {
           fireEvent.blur(input);
         });
 
-        act(() => {
+        await wait(() => {
           fireEvent.focus(input);
         });
       });

--- a/src/components/shared/__tests__/__snapshots__/EditText.test.tsx.snap
+++ b/src/components/shared/__tests__/__snapshots__/EditText.test.tsx.snap
@@ -20,8 +20,8 @@ exports[`[EditText] Type: [box] renders without crashing 1`] = `
           "fontWeight": "500",
           "marginBottom": 5,
         },
-        null,
         undefined,
+        null,
       ]
     }
   >
@@ -48,19 +48,17 @@ exports[`[EditText] Type: [box] renders without crashing 1`] = `
           },
           Object {
             "borderColor": "#eaeaf9",
-          },
-          null,
-          Object {
             "borderRadius": 3,
             "borderWidth": 0.6,
           },
+          undefined,
+          null,
           Object {
             "paddingLeft": 15,
           },
           Object {
             "paddingRight": 15,
           },
-          undefined,
         ]
       }
     >
@@ -113,8 +111,8 @@ exports[`[EditText] Type: [default] renders without crashing 1`] = `
           "fontWeight": "500",
           "marginBottom": 5,
         },
-        null,
         undefined,
+        null,
       ]
     }
   >
@@ -140,13 +138,11 @@ exports[`[EditText] Type: [default] renders without crashing 1`] = `
             "width": "100%",
           },
           Object {
+            "borderBottomWidth": 0.6,
             "borderColor": "#eaeaf9",
           },
-          null,
-          Object {
-            "borderBottomWidth": 0.6,
-          },
           undefined,
+          null,
         ]
       }
     >
@@ -200,13 +196,11 @@ exports[`[EditText] Type: [row] renders without crashing 1`] = `
           "width": "100%",
         },
         Object {
+          "borderBottomWidth": 0.6,
           "borderColor": "#eaeaf9",
         },
-        null,
-        Object {
-          "borderBottomWidth": 0.6,
-        },
         undefined,
+        null,
       ]
     }
   >
@@ -267,8 +261,8 @@ exports[`[EditText] Type: [rowBox] renders without crashing 1`] = `
           "borderRadius": 3,
           "borderWidth": 0.6,
         },
-        null,
         undefined,
+        null,
       ]
     }
   >


### PR DESCRIPTION
## Description

- For highlighting when editText component is focused(same when function `onFocus` is running), I added props below two.
    - `focusedLabelStyle`: TextStyle
    - `focusedBorderWidth`: number

        [README.md](https://github.com/ilikeu7246/dooboo-ui-native/blob/feat/edit-text-add-props/src/components/shared/EditText/README.md) related to this PR is here.
And this is preview image of feature i implemented.

        ![focused-ex](https://user-images.githubusercontent.com/31176502/72157237-bdf4d080-33fa-11ea-95a3-95c8eb2bb1b1.gif)

- Fix test Error caused by wrong using `async await`

    When `yarn test`, there was warning message like this.

    ```
    Warning: You called act(async () => ...) without await. This could lead to unexpected testing behaviour, interleaving multiple act calls and mixing their scopes. You should - await act(async () => ...);
    ```

    This code is one of the wrong codes.

    ```
    act(() => {
          fireEvent.focus(input)
    })
    ```
    so I fixed like this.

    ```
     await wait(() => {
          fireEvent.blur(input);
     });
    ```

- I added `'@typescript-eslint/ban-ts-ignore': 0` in `.eslintrc.js`

## Checklist

- [x] I added props for running onFocus. `focusedLabelStyle`, `focusedBorderWidth`
- [x]  I added ` '@typescript-eslint/ban-ts-ignore': 0 ` in `.eslintrc.js`.
- [x] I fixed test code error caused by using `act` without `await`.
- [x] I updated README.md according to changed things.
