### PR TITLE
:label: Make TinderCard generic

### DIFF
--- a/src/components/shared/TinderCard/index.tsx
+++ b/src/components/shared/TinderCard/index.tsx
@@ -8,8 +8,9 @@ import {
   View,
 } from 'react-native';
 import React, {
+  PropsWithChildren,
   ReactElement,
-  RefForwardingComponent,
+  Ref,
   forwardRef,
   useCallback,
   useImperativeHandle,
@@ -33,13 +34,13 @@ export interface TinderCardRef {
   forceSwipe: (direction: TinderCardDirection) => void;
 }
 
-interface Props {
+interface Props<T> {
   testID?: string;
-  onSwipeRight?: (item: any) => void;
-  onSwipeLeft?: (item: any) => void;
+  onSwipeRight?: (item: T) => void;
+  onSwipeLeft?: (item: T) => void;
   onCancel?: () => void;
-  data: any[];
-  renderCards: (item: any, type?: number) => ReactElement;
+  data: T[];
+  renderCards: (item: T, type?: number) => ReactElement;
   renderNoMoreCards: () => ReactElement;
   renderCardLabel?: (type: number) => ReactElement;
   rotate?: boolean;
@@ -67,10 +68,10 @@ const NoCard = styled.View`
   padding: 10px;
 `;
 
-const TinderCard: RefForwardingComponent<TinderCardRef, Props> = (
-  props,
-  ref,
-): ReactElement => {
+function TinderCard<T>(
+  props: PropsWithChildren<Props<T>>,
+  ref: Ref<TinderCardRef>,
+): ReactElement {
   const [cardIndex, setCardIndex] = useState(0);
   const [type, setType] = useState(0);
   const position = useMemo(() => new Animated.ValueXY(), []);


### PR DESCRIPTION
## Description

How about this? 
It removes any type. 
But it cannot make the exported result of `forwardRef(TinderCard)` generic.

## Related Issues

#82 

## Tests

I didn't add any tests.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui-native/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
