### PR TITLE
Fix onFocus & onBlur function

### DIFF
--- a/src/components/shared/EditText/index.tsx
+++ b/src/components/shared/EditText/index.tsx
@@ -215,8 +215,18 @@ function EditText(props: Props): ReactElement {
                 {...textInputProps}
                 testID={testID}
                 autoCapitalize={autoCapitalize}
-                onFocus={(): void => setFocus(true)}
-                onBlur={(): void => setFocus(false)}
+                onFocus={(): void => {
+                  setFocus(true);
+                  if (onFocus) {
+                    onFocus();
+                  }
+                }}
+                onBlur={(): void => {
+                  setFocus(false);
+                  if (onBlur) {
+                    onBlur();
+                  }
+                }}
                 placeholder={placeholder}
                 placeholderTextColor={placeholderTextColor}
                 value={value}
@@ -354,8 +364,18 @@ function EditText(props: Props): ReactElement {
                 {...textInputProps}
                 testID={testID}
                 autoCapitalize={autoCapitalize}
-                onFocus={(): void => setFocus(true)}
-                onBlur={(): void => setFocus(false)}
+                onFocus={(): void => {
+                  setFocus(true);
+                  if (onFocus) {
+                    onFocus();
+                  }
+                }}
+                onBlur={(): void => {
+                  setFocus(false);
+                  if (onBlur) {
+                    onBlur();
+                  }
+                }}
                 placeholder={placeholder}
                 placeholderTextColor={placeholderTextColor}
                 value={value}


### PR DESCRIPTION
## Description

Fix onFocus, onBlur functions on EditText Component.
 -  The onfocus and onblur props functions are not called when the component type is BOX or DEFAULT.

## Related Issues

## Tests

## Checklist
- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui-native/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
