### PR TITLE
add keyboardType props to TextInput on EditText Screen

### DIFF
--- a/src/components/shared/EditText/index.tsx
+++ b/src/components/shared/EditText/index.tsx
@@ -234,6 +234,7 @@ function EditText(props: Props): ReactElement {
                 onChangeText={onChangeText}
                 secureTextEntry={secureTextEntry}
                 onSubmitEditing={onSubmitEditing}
+                keyboardType={keyboardType}
               />
             </StyledLine>
           </StyledContent>
@@ -383,6 +384,7 @@ function EditText(props: Props): ReactElement {
                 onChangeText={onChangeText}
                 secureTextEntry={secureTextEntry}
                 onSubmitEditing={onSubmitEditing}
+                keyboardType={keyboardType}
               />
               {
                 rightElement


### PR DESCRIPTION
add keyboardType to TextInput props on EditText Screen

* The keyboardType prop was not in two cases of TextInput (DEFAULT and BOX)


## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui-native/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
