### PR TITLE
[Accordion] Fix a Bug which hides the contents

### DIFF
--- a/src/components/shared/Accordion/index.tsx
+++ b/src/components/shared/Accordion/index.tsx
@@ -75,6 +75,8 @@ enum AnimationType {
   null = 'null',
 }
 
+let lastContentVisibleState: ContentVisibleState;
+
 function Accordion(props: Props): React.ReactElement {
   const [animatedValue, setAnimatedValue] = useState<Animated.Value | null>(
     null,
@@ -98,11 +100,11 @@ function Accordion(props: Props): React.ReactElement {
       : (currentAnimation === AnimationType.hideContent
         ? AnimationType.showContent
         : AnimationType.hideContent);
-    this.lastContentVisibleState = {
+    lastContentVisibleState = {
       isContentVisible: isContentVisible,
       currentAnimation: targetAnimation,
     };
-    setContentVisibleState(this.lastContentVisibleState);
+    setContentVisibleState(lastContentVisibleState);
   };
 
   useEffect(() => {
@@ -120,7 +122,7 @@ function Accordion(props: Props): React.ReactElement {
       Animated.spring(animatedValue, {
         toValue: finalValue,
       }).start(() => {
-        if (this.lastContentVisibleState === contentVisibleState) {
+        if (lastContentVisibleState === contentVisibleState) {
           setContentVisibleState({
             isContentVisible: !isCollapsing,
             currentAnimation: AnimationType.null,


### PR DESCRIPTION
## Description

In this PR, The contentHeight value of the Accordion content won't be updated if the content is not visible or on trans state and the headerHeight value doesn't be updated after it mounted. For this, I added animationType enum and ContentVisibleState interface. 

## Related Issues

#178 

## Tests

I didn't add or update any tests.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui-native/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
