### PR TITLE
Guide to props changing container type

### DIFF
--- a/src/components/shared/EditText/README.md
+++ b/src/components/shared/EditText/README.md
@@ -17,13 +17,13 @@
 |                      | necessary | types                  | default              |
 | -------------------- | --------- | ---------------------- | -------------------- |
 | testID               |           | string                 |                      |
+| type                 |           | string                 |     `underlined`     |
 | errorTestID          |           | string                 |                      |
 | isRow                |           | boolean                |        `false`       |
 | style                |           | `ViewStyle`            |                      |
 | label                |           | string                 |                      |
 | labelTextStyle       |           | `TextStyle`            |                      |
 | value                |           | `TextInputProps`       |                      |
-| inputContainerType   |           | string                 |     `underlined`     |
 | inputContainerRadius |           | string                 |          `3`         |
 | borderStyle          |           | `ViewStyle`            |                      |
 | borderWidth          |           | number                 |         `0.6`        |


### PR DESCRIPTION
`inputContainerType` props to `box` not working in my case, then `type` prop did that

## Description

The `inputContainerType` prop to box won't change `EditText` style, but `type` prop.
Can you update README.md?
