### PR TITLE
Fix about SnackbarProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you want to use only `SwitchToggle`, you can install it by running `yarn add 
 - [SearchInput](https://github.com/dooboolab/dooboo-ui-native/tree/master/src/components/shared/SearchInput)
   - `@dooboo-ui/native-search-input`
 - [Snackbar](src/components/shared/Snackbar)
-  - `@dooboo-ui/snackbar` (WIP)
+  - `@dooboo-ui/snackbar`
 - [SwitchToggle](https://github.com/dooboolab/dooboo-ui-native/tree/master/src/components/shared/SwitchToggle)
   - `@dooboo-ui/native-switch-toggle`
 - [Slider](https://github.com/dooboolab/dooboo-ui-native/tree/master/src/components/shared/Slider)

--- a/src/components/shared/Snackbar/README.md
+++ b/src/components/shared/Snackbar/README.md
@@ -137,7 +137,19 @@ You can also set SnackbarProvider to use Snackbar component.
   }
 
 ```
-The SnackbarProvider covers the children with SafeAreaView by default so if you want to use the whole screen in the child views then use useWholeScreen option.
+For versions after iPhone x, Snackbar will overlap with the gesture bar. Previously, Snackbar was put in SafeAreaView, but this could be a problem and changed to use View. We recommend that using 'defaultContent' like below.
+
+```typescript
+  function Provider(): React.ReactElement {
+    return (
+      <SnackbarProvider
+        defaultContent={{ containerStyle: { bottom: safeAreaBottom + 10 }}}
+      >
+        <Container/>
+      </SnackbarProvider>
+    );
+  }
+```
 
 - Using some Action
 

--- a/src/components/shared/Snackbar/Snackbar.tsx
+++ b/src/components/shared/Snackbar/Snackbar.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
-import { Animated, Dimensions, StyleSheet, TextStyle, ViewStyle } from 'react-native';
+import {
+  Animated, Dimensions, StyleSheet, TextStyle, ViewStyle,
+} from 'react-native';
 
 import styled from 'styled-components/native';
 
@@ -16,6 +18,7 @@ const styles = StyleSheet.create({
     maxWidth,
     textAlign: 'left',
     alignItems: 'center',
+    alignSelf: 'center',
     position: 'absolute',
     fontSize: 16,
     paddingHorizontal: 16,
@@ -23,7 +26,6 @@ const styles = StyleSheet.create({
     bottom: 10,
     backgroundColor: '#87b5ff',
     borderRadius: 10,
-    alignSelf: 'center',
   },
 });
 
@@ -81,13 +83,17 @@ export enum Timer {
 
 const Snackbar = (props: SnackbarProps, ref: React.Ref<SnackbarRef>): React.ReactElement => {
   const { testID } = props;
-  const [showingState, setShowingState] = React.useState<ShowingState>({ isVisible: false, isShowing: false });
+  const [showingState, setShowingState] = React.useState<ShowingState>(
+    { isVisible: false, isShowing: false },
+  );
   const [content, setContent] = React.useState<Content>({ text: '', timer: Timer.SHORT });
-  const { text, actionText, messageStyle, actionStyle, containerStyle, timer = Timer.SHORT, onPressAction } = content;
+  const {
+    text, actionText, messageStyle, actionStyle, containerStyle, timer = Timer.SHORT, onPressAction,
+  } = content;
   const { isShowing, isVisible, timeout } = showingState;
   const [fadeAnim] = React.useState(new Animated.Value(0));
-  const show = (content: Content): void => {
-    setContent(content);
+  const show = (c: Content): void => {
+    setContent(c);
     timeout && clearTimeout(timeout);
     setShowingState((prevState) => Object.assign(Object.assign({}, prevState), { isShowing: true }));
   };
@@ -96,19 +102,21 @@ const Snackbar = (props: SnackbarProps, ref: React.Ref<SnackbarRef>): React.Reac
       fadeAnim,
       {
         toValue: 0,
-        duration: duration,
+        duration,
       },
-    ).start(() => setShowingState((prevState) => Object.assign(Object.assign({}, prevState), { isVisible: false })));
+    ).start(() => setShowingState(
+      (prevState) => Object.assign(Object.assign({}, prevState), { isVisible: false }),
+    ));
   };
   React.useEffect(() => {
     if (isShowing) {
       if (isVisible) {
         hide(50);
       } else {
-        const timeout = setTimeout(() => {
+        const hideTimeout = setTimeout(() => {
           hide();
         }, timer + 200);
-        setShowingState({ isShowing: false, isVisible: true, timeout });
+        setShowingState({ isShowing: false, isVisible: true, timeout: hideTimeout });
         Animated.timing(
           fadeAnim,
           {
@@ -125,7 +133,10 @@ const Snackbar = (props: SnackbarProps, ref: React.Ref<SnackbarRef>): React.Reac
   return (
     <>
       {showingState.isVisible && (
-        <Animated.View testID={testID} style={[styles.container, containerStyle, { opacity: fadeAnim }]}>
+        <Animated.View
+          testID={testID}
+          style={[styles.container, containerStyle, { opacity: fadeAnim }]}
+        >
           <MessageText style={messageStyle}>{text}</MessageText>
           {actionText && (
             <ActionContainer>

--- a/src/components/shared/Snackbar/Snackbar.tsx
+++ b/src/components/shared/Snackbar/Snackbar.tsx
@@ -23,6 +23,7 @@ const styles = StyleSheet.create({
     bottom: 10,
     backgroundColor: '#87b5ff',
     borderRadius: 10,
+    alignSelf: 'center',
   },
 });
 

--- a/src/components/shared/Snackbar/index.tsx
+++ b/src/components/shared/Snackbar/index.tsx
@@ -28,7 +28,7 @@ function SnackbarProvider(props: SnackbarProviderProps): React.ReactElement {
   };
   const Container = useWholeScreen ? View : SafeAreaView;
   return (
-    <Container style={{ flex: 1, alignItems: 'center' }}>
+    <Container style={{ flex: 1 }}>
       <SnackbarContext.Provider value={{ show }}>{children}</SnackbarContext.Provider>
       <Snackbar ref={snackbar} />
     </Container>);

--- a/src/components/shared/Snackbar/index.tsx
+++ b/src/components/shared/Snackbar/index.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useRef } from 'react';
-import { SafeAreaView, View } from 'react-native';
 import Snackbar, { Content, SnackbarRef } from './Snackbar';
+import { View } from 'react-native';
 
 interface SnackbarContext {
   show(content: Content): void;
@@ -17,21 +17,20 @@ const useCtx = (): SnackbarContext | undefined => {
 
 export interface SnackbarProviderProps {
   children?: React.ReactElement;
-  useWholeScreen?: boolean;
+  defaultContent?: Partial<Content>;
 }
 
 function SnackbarProvider(props: SnackbarProviderProps): React.ReactElement {
-  const { children, useWholeScreen } = props;
+  const { children, defaultContent = {} } = props;
   const snackbar = useRef<SnackbarRef>() as React.MutableRefObject<SnackbarRef>;
   const show = (content: Content): void => {
-    snackbar.current && snackbar.current.show(content);
+    snackbar.current && snackbar.current.show({ ...defaultContent, ...content });
   };
-  const Container = useWholeScreen ? View : SafeAreaView;
   return (
-    <Container style={{ flex: 1 }}>
+    <View style={{ flex: 1 }}>
       <SnackbarContext.Provider value={{ show }}>{children}</SnackbarContext.Provider>
       <Snackbar ref={snackbar} />
-    </Container>);
+    </View>);
 }
 
 export { useCtx as useSnackbarContext, SnackbarProvider };

--- a/src/components/shared/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/shared/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`[Snackbar] using provider renders TestElement using whole screen view w
 `;
 
 exports[`[Snackbar] using provider renders TestElement without crashing 1`] = `
-<SafeAreaView
+<View
   style={
     Object {
       "flex": 1,
@@ -184,7 +184,7 @@ exports[`[Snackbar] using provider renders TestElement without crashing 1`] = `
       </Text>
     </TouchableOpacity>
   </View>
-</SafeAreaView>
+</View>
 `;
 
 exports[`[Snackbar] using provider should simulate showing snackbar 1`] = `
@@ -197,7 +197,7 @@ exports[`[Snackbar] using provider should simulate showing snackbar 1`] = `
     }
   }
 >
-  <SafeAreaView
+  <View
     style={
       Object {
         "flex": 1,
@@ -301,6 +301,6 @@ exports[`[Snackbar] using provider should simulate showing snackbar 1`] = `
         </TouchableOpacity>
       </View>
     </View>
-  </SafeAreaView>
+  </View>
 </View>
 `;

--- a/src/components/shared/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/shared/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -49,6 +49,7 @@ exports[`[Snackbar] should simulate showing snackbar 1`] = `
       style={
         Object {
           "alignItems": "center",
+          "alignSelf": "center",
           "backgroundColor": "#87b5ff",
           "borderRadius": 10,
           "bottom": 10,
@@ -134,7 +135,6 @@ exports[`[Snackbar] using provider renders TestElement using whole screen view w
 <View
   style={
     Object {
-      "alignItems": "center",
       "flex": 1,
     }
   }
@@ -163,7 +163,6 @@ exports[`[Snackbar] using provider renders TestElement without crashing 1`] = `
 <SafeAreaView
   style={
     Object {
-      "alignItems": "center",
       "flex": 1,
     }
   }
@@ -201,7 +200,6 @@ exports[`[Snackbar] using provider should simulate showing snackbar 1`] = `
   <SafeAreaView
     style={
       Object {
-        "alignItems": "center",
         "flex": 1,
       }
     }
@@ -226,6 +224,7 @@ exports[`[Snackbar] using provider should simulate showing snackbar 1`] = `
       style={
         Object {
           "alignItems": "center",
+          "alignSelf": "center",
           "backgroundColor": "#87b5ff",
           "borderRadius": 10,
           "bottom": 10,


### PR DESCRIPTION
## Description

It's about using react-navigation. When I wrapped ```NavigationContainer``` with the SnackbarProvider, the screen did not show anything. I don't know why but when I tried to add Snackbar without SnackbarProvider to the outer view of the Navigation like below, then the snackbar shows. 
```typscript
<View style={{ flex: 1 }}>
      <Stack.Navigator>
      ...
      </Stack.Navigator>
    <Snackbar ref={snackbar} />
</View>
```
And It aligned to left. When I  changed the alignItems to 'center', child views disappeared. 
I don't know why but when removing the align-items option of the wrapper view, children appear. 
So I removed the option of view in SnackbarProvider and added 'alignSelf' option to the Snackbar component. 

## Related Issues

#184 

## Tests

x

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui-native/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
