### PR TITLE
Set explicit useNativeDriver (fixes #189)

### DIFF
--- a/src/components/shared/SwitchToggle/index.tsx
+++ b/src/components/shared/SwitchToggle/index.tsx
@@ -59,6 +59,7 @@ function SwitchToggle(props: Props): React.ReactElement {
       fromValue: props.switchOn ? 0 : 1,
       toValue: props.switchOn ? 1 : 0,
       duration: props.duration,
+      useNativeDriver: false,
     };
     Animated.timing(animXValue, animValue).start();
   };


### PR DESCRIPTION
- fixes the warning in RN 0.62

## Description

React Native 0.62 throws a warning if useNativeDriver is not explicitly specified in animations:

```
Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false`
    in SwitchToggle (at Switch.js:39)
```

## Related Issues

https://github.com/dooboolab/dooboo-ui-native/issues/189

## Tests

Have tested this manually in my own project

## Checklist

I've created the PR from Github