### PR TITLE
Fix wrong storybook path in postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "pre": "lerna clean --yes && lerna bootstrap && lerna run build",
-    "postinstall": "dooboolab-welcome postinstall && cp -R .storybook storybook",
+    "postinstall": "dooboolab-welcome postinstall && rm -rf storybook && cp -R .storybook storybook",
     "publish": "yarn build && cd lib && npm publish && cd ..",
     "publish:packages": "yarn pre && yarn build-packages && lerna exec -- npm publish",
     "lint": "eslint main packages stories --ext .ts,.tsx,.js,.jsx",


### PR DESCRIPTION
## Description

`yarn build-storybook`

This script makes another folder in the storybook folder if there is the storybook folder already.

```
storybook
 L storybook
```

This PR is fixing it. 

Before: `"postinstall": "dooboolab-welcome postinstall && cp -R .storybook storybook"`
After: `"postinstall": "dooboolab-welcome postinstall && rm -rf storybook && cp -R .storybook storybook"`

## Related Issues

## Tests

Local test 

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
