### PR TITLE
Fix `Style property 'xxx' is not supported by native animated module` iOS runtime error

### DIFF
--- a/main/Accordion/index.tsx
+++ b/main/Accordion/index.tsx
@@ -1,4 +1,4 @@
-import { Animated, LayoutChangeEvent, View } from 'react-native';
+import { Animated, LayoutChangeEvent, Platform, View } from 'react-native';
 import React, { FC, ReactElement, useEffect, useRef, useState } from 'react';
 
 import styled from 'styled-components/native';
@@ -73,7 +73,7 @@ const Accordion: FC<Props> = (props) => {
       Animated.timing(animValue, {
         toValue: targetValue,
         duration: props.duration || 300,
-        useNativeDriver: false,
+        useNativeDriver: Platform.OS === 'android',
       }).start();
 
       return;

--- a/main/Accordion/index.tsx
+++ b/main/Accordion/index.tsx
@@ -73,7 +73,7 @@ const Accordion: FC<Props> = (props) => {
       Animated.timing(animValue, {
         toValue: targetValue,
         duration: props.duration || 300,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }).start();
 
       return;

--- a/main/RadioButton/index.tsx
+++ b/main/RadioButton/index.tsx
@@ -96,7 +96,7 @@ const InnerCircleAnim = ({
       },
       easing: Easing.ease,
       duration: 80,
-      useNativeDriver: true,
+      useNativeDriver: false,
     }).start();
   }, []);
 

--- a/main/RadioButton/index.tsx
+++ b/main/RadioButton/index.tsx
@@ -1,4 +1,4 @@
-import { Animated, Easing } from 'react-native';
+import { Animated, Easing, Platform } from 'react-native';
 import React, { useState } from 'react';
 
 import styled from 'styled-components/native';
@@ -96,7 +96,7 @@ const InnerCircleAnim = ({
       },
       easing: Easing.ease,
       duration: 80,
-      useNativeDriver: false,
+      useNativeDriver: Platform.OS === 'android',
     }).start();
   }, []);
 

--- a/main/Slider/index.tsx
+++ b/main/Slider/index.tsx
@@ -97,7 +97,7 @@ const Slider: FC<Props> = ({
       toValue: percent,
       duration: 255,
       easing: Easing.elastic(1),
-      useNativeDriver: true,
+      useNativeDriver: Platform.OS === 'android',
     }).start();
   }, [percent]);
 


### PR DESCRIPTION
## Description

We cannot native drive animation to change some style properties in iOS.

`Style property 'height' is not supported by native animated module` 
![image](https://user-images.githubusercontent.com/216363/85571319-059cab00-b66f-11ea-8159-acdb492703d7.png)

## Related Issues

https://github.com/facebook/react-native/issues/13150

## Tests

not changed 

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
