### PR TITLE
[Bugfix]Fix that Tindercard can't import appropriate modules because of wrong path

### DIFF
--- a/stories/packages/TinderCard.stories.tsx
+++ b/stories/packages/TinderCard.stories.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import TinderCard, { TinderCardDirection, TinderCardRef } from '../../packages/TinderCard/lib';
+import TinderCard, { TinderCardDirection, TinderCardRef } from '../../packages/TinderCard';
 
 import { ContainerDeco } from '../../storybook/decorators';
 import { storiesOf } from '@storybook/react-native';


### PR DESCRIPTION
## Description

Fix that Tindercard can't import appropriate modules because of wrong path.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
