### PR TITLE
Use 0 instead of `undefined` value

### DIFF
--- a/main/SwitchToggle/index.tsx
+++ b/main/SwitchToggle/index.tsx
@@ -68,7 +68,7 @@ function SwitchToggle(props: Props): React.ReactElement {
     props.containerStyle && props.circleStyle
       ? (props.containerStyle.width as number) -
         ((props.circleStyle.width as number) +
-          (props.containerStyle.padding as number) * 2)
+          (props.containerStyle.padding as number || 0) * 2)
       : 0;
   const circlePosXEnd = endPos;
   const [circlePosXStart] = useState(getStart());


### PR DESCRIPTION
When calculating endPos at SwitchToggle.

## Description

Like below, if someone doesn't set the container padding value, then the SwitchToggle will not move even it touched.
```typescript
    <SwitchToggle
      containerStyle={{
        marginTop: 16,
        width: 108,
        height: 48,
        borderRadius: 25,
        backgroundColor: '#ccc',
      }}
      circleStyle={{
        width: 48,
        height: 48,
        borderRadius: 24,
        backgroundColor: 'white',
      }}
      switchOn={switchOn2}
      onPress={(): void => setSwitchOn2(!switchOn2)}
      circleColorOff="green"
      circleColorOn="red"
      duration={500}
    />
```
![Jul-06-2020 18-23-23](https://user-images.githubusercontent.com/17980230/86577934-f6debe00-bfb5-11ea-88cf-a16f916c0bdd.gif)
It because calculated endPos value will be 0 when the padding value is undefined.
So I changed that use 0 instead of undefined value.
![Jul-06-2020 18-23-36](https://user-images.githubusercontent.com/17980230/86577958-00682600-bfb6-11ea-9f13-8a60bee6b830.gif)

## Related Issues

#190 

## Tests

I didn't add any tests.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
