### PR TITLE
Update README.md (expo-web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,22 +80,22 @@ or ```npm install @expo/webpack-config```
 2. Create webpack.config.js in root path and Add below code.
 See [issue](https://forums.expo.io/t/error-when-running-expo-start-web/33096/3) below for more details.
 
-```js
-const createExpoWebpackConfigAsync = require('@expo/webpack-config');
+    ```javascript
+    const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 
-module.exports = async function(env, argv) {
-  const config = await createExpoWebpackConfigAsync(
-    {
-      ...env,
-      babel: {
-        dangerouslyAddModulePathsToTranspile: [
-          'dooboo-ui',
-        ],
-      },
-    },
-    argv
-  );
-  return config;
-};
-```
+    module.exports = async function(env, argv) {
+      const config = await createExpoWebpackConfigAsync(
+        {
+          ...env,
+          babel: {
+            dangerouslyAddModulePathsToTranspile: [
+              'dooboo-ui',
+            ],
+          },
+        },
+        argv
+      );
+      return config;
+    };
+    ```
 

--- a/README.md
+++ b/README.md
@@ -69,3 +69,33 @@ We aim to support `react-native` ui components in all platforms and we are curre
 - [Snackbar](https://github.com/dooboolab/dooboo-ui/tree/master/packages/Snackbar)
 - [theme](https://github.com/dooboolab/dooboo-ui/tree/master/packages/theme)
 - [TinderCard](https://github.com/dooboolab/dooboo-ui/tree/master/packages/TinderCard)
+
+## Expo-web
+
+You need to set webpack for using "dooboo-ui" in expo-web.
+1. Install @expo/webpack-config in your expo's project.
+```yarn add @expo/webpack-config``` 
+or ```npm install @expo/webpack-config```
+
+2. Create webpack.config.js in root path and Add below code.
+See [issue](https://forums.expo.io/t/error-when-running-expo-start-web/33096/3) below for more details.
+
+```js
+const createExpoWebpackConfigAsync = require('@expo/webpack-config');
+
+module.exports = async function(env, argv) {
+  const config = await createExpoWebpackConfigAsync(
+    {
+      ...env,
+      babel: {
+        dangerouslyAddModulePathsToTranspile: [
+          'dooboo-ui',
+        ],
+      },
+    },
+    argv
+  );
+  return config;
+};
+```
+

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ We aim to support `react-native` ui components in all platforms and we are curre
 - [theme](https://github.com/dooboolab/dooboo-ui/tree/master/packages/theme)
 - [TinderCard](https://github.com/dooboolab/dooboo-ui/tree/master/packages/TinderCard)
 
-## Expo-web
+## Troubleshoot
+
+#### Workaround when you face error in expo web
 
 You need to set webpack for using "dooboo-ui" in expo-web.
 1. Install @expo/webpack-config in your expo's project.


### PR DESCRIPTION
## Description

Update README.md.
Add comment required to use dooboo-ui in expo-web.

## Related Issues

`Module parse failed: Unexpected token (14:12)You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders`

## Checklist

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
