### PR TITLE
[RadioButton]Change useState to useRef and some minor things

### DIFF
--- a/main/RadioButton/index.tsx
+++ b/main/RadioButton/index.tsx
@@ -1,5 +1,5 @@
-import { Animated, Easing, Platform } from 'react-native';
-import React, { useState } from 'react';
+import { Animated, Easing } from 'react-native';
+import React, { useRef } from 'react';
 
 import styled from 'styled-components/native';
 
@@ -34,7 +34,7 @@ interface RadioButtonProps {
 const DEFAULT_CIRCLE: {
   [key: string]: string;
 } = {
-  OUTER_SIZE: '23',
+  OUTER_SIZE: '24',
   COLOR: 'rgba(0, 0, 0, 0.54)',
   BORDER_RADIUS: '12',
 };
@@ -42,7 +42,7 @@ const DEFAULT_CIRCLE: {
 const COLOR: {
   [key: string]: string;
 } = {
-  LIGHTGRAY: '#c8c8c8',
+  LIGHTGRAY: '#E0E0E0',
   GRAY59: '#969696',
   BLACK: '#000000',
 };
@@ -75,9 +75,9 @@ const getCircleStyles = (size: number, color: string): ICircleProps => {
   return {
     color,
     size,
-    innerSize: size / 2 - size / 8,
+    innerSize: Math.floor(size - size / 3),
     borderRadius: size / 2,
-    borderWidth: size / 6,
+    borderWidth: size / 10,
   };
 };
 
@@ -86,7 +86,7 @@ const InnerCircleAnim = ({
   borderRadius,
   color,
 }: ICircleProps): React.ReactElement => {
-  const [circleAnim] = useState(new Animated.ValueXY());
+  const circleAnim = useRef(new Animated.ValueXY()).current;
 
   React.useEffect(() => {
     Animated.timing(circleAnim, {
@@ -96,7 +96,7 @@ const InnerCircleAnim = ({
       },
       easing: Easing.ease,
       duration: 80,
-      useNativeDriver: Platform.OS === 'android',
+      useNativeDriver: true,
     }).start();
   }, []);
 
@@ -104,8 +104,8 @@ const InnerCircleAnim = ({
     <Animated.View
       style={{
         borderRadius,
-        width: circleAnim.x,
-        height: circleAnim.y,
+        width: innerSize,
+        height: innerSize,
         backgroundColor: color,
       }}
     />
@@ -141,7 +141,7 @@ function RadioButton(props: RadioButtonProps): React.ReactElement {
       isLabelColumn={isLabelColumn}
       onPress={(): void => onPress?.(value)}>
       {isLabelFront && <SCLabelText disabled={disabled}>{label}</SCLabelText>}
-      <SCOuterCircle {...circleStyles}>
+      <SCOuterCircle {...circleStyles} style={ disabled && { backgroundColor: COLOR.LIGHTGRAY }}>
         {isSelected && <InnerCircleAnim {...circleStyles} />}
       </SCOuterCircle>
       {!isLabelFront && <SCLabelText disabled={disabled}>{label}</SCLabelText>}

--- a/main/__tests__/__snapshots__/RadioButton.test.tsx.snap
+++ b/main/__tests__/__snapshots__/RadioButton.test.tsx.snap
@@ -33,26 +33,27 @@ exports[`[RadioButton] render [RadioButton] Interaction should simulate props 1`
     
   </Text>
   <View
-    borderRadius={11.5}
-    borderWidth={3.8333333333333335}
+    borderRadius={12}
+    borderWidth={2.4}
     color="rgba(0, 0, 0, 0.54)"
-    innerSize={8.625}
-    size={23}
+    innerSize={16}
+    size={24}
     style={
       Array [
         Object {
           "alignItems": "center",
           "borderColor": "rgba(0, 0, 0, 0.54)",
-          "borderRadius": 11.5,
-          "borderWidth": 3.8333333333333335,
-          "height": 23,
+          "borderRadius": 12,
+          "borderWidth": 2.4,
+          "height": 24,
           "justifyContent": "center",
           "marginBottom": 7,
           "marginLeft": 7,
           "marginRight": 7,
           "marginTop": 7,
-          "width": 23,
+          "width": 24,
         },
+        false,
       ]
     }
   >
@@ -60,9 +61,9 @@ exports[`[RadioButton] render [RadioButton] Interaction should simulate props 1`
       style={
         Object {
           "backgroundColor": "rgba(0, 0, 0, 0.54)",
-          "borderRadius": 11.5,
-          "height": 0,
-          "width": 0,
+          "borderRadius": 12,
+          "height": 16,
+          "width": 16,
         }
       }
     />
@@ -91,25 +92,28 @@ exports[`[RadioButton] render [RadioButton] Interaction should simulate props 2`
   }
 >
   <View
-    borderRadius={11.5}
-    borderWidth={3.8333333333333335}
-    color="#c8c8c8"
-    innerSize={8.625}
-    size={23}
+    borderRadius={12}
+    borderWidth={2.4}
+    color="#E0E0E0"
+    innerSize={16}
+    size={24}
     style={
       Array [
         Object {
           "alignItems": "center",
-          "borderColor": "#c8c8c8",
-          "borderRadius": 11.5,
-          "borderWidth": 3.8333333333333335,
-          "height": 23,
+          "borderColor": "#E0E0E0",
+          "borderRadius": 12,
+          "borderWidth": 2.4,
+          "height": 24,
           "justifyContent": "center",
           "marginBottom": 7,
           "marginLeft": 7,
           "marginRight": 7,
           "marginTop": 7,
-          "width": 23,
+          "width": 24,
+        },
+        Object {
+          "backgroundColor": "#E0E0E0",
         },
       ]
     }
@@ -117,10 +121,10 @@ exports[`[RadioButton] render [RadioButton] Interaction should simulate props 2`
     <View
       style={
         Object {
-          "backgroundColor": "#c8c8c8",
-          "borderRadius": 11.5,
-          "height": 0,
-          "width": 0,
+          "backgroundColor": "#E0E0E0",
+          "borderRadius": 12,
+          "height": 16,
+          "width": 16,
         }
       }
     />
@@ -161,26 +165,27 @@ exports[`[RadioButton] render [RadioButton] Interaction should simulate props 3`
   }
 >
   <View
-    borderRadius={11.5}
-    borderWidth={3.8333333333333335}
+    borderRadius={12}
+    borderWidth={2.4}
     color="rgba(0, 0, 0, 0.54)"
-    innerSize={8.625}
-    size={23}
+    innerSize={16}
+    size={24}
     style={
       Array [
         Object {
           "alignItems": "center",
           "borderColor": "rgba(0, 0, 0, 0.54)",
-          "borderRadius": 11.5,
-          "borderWidth": 3.8333333333333335,
-          "height": 23,
+          "borderRadius": 12,
+          "borderWidth": 2.4,
+          "height": 24,
           "justifyContent": "center",
           "marginBottom": 7,
           "marginLeft": 7,
           "marginRight": 7,
           "marginTop": 7,
-          "width": 23,
+          "width": 24,
         },
+        false,
       ]
     }
   />
@@ -220,26 +225,27 @@ exports[`[RadioButton] render renders without crashing 1`] = `
   }
 >
   <View
-    borderRadius={11.5}
-    borderWidth={3.8333333333333335}
+    borderRadius={12}
+    borderWidth={2.4}
     color="rgba(0, 0, 0, 0.54)"
-    innerSize={8.625}
-    size={23}
+    innerSize={16}
+    size={24}
     style={
       Array [
         Object {
           "alignItems": "center",
           "borderColor": "rgba(0, 0, 0, 0.54)",
-          "borderRadius": 11.5,
-          "borderWidth": 3.8333333333333335,
-          "height": 23,
+          "borderRadius": 12,
+          "borderWidth": 2.4,
+          "height": 24,
           "justifyContent": "center",
           "marginBottom": 7,
           "marginLeft": 7,
           "marginRight": 7,
           "marginTop": 7,
-          "width": 23,
+          "width": 24,
         },
+        false,
       ]
     }
   >
@@ -247,9 +253,9 @@ exports[`[RadioButton] render renders without crashing 1`] = `
       style={
         Object {
           "backgroundColor": "rgba(0, 0, 0, 0.54)",
-          "borderRadius": 11.5,
-          "height": 0,
-          "width": 0,
+          "borderRadius": 12,
+          "height": 16,
+          "width": 16,
         }
       }
     />


### PR DESCRIPTION
## Description

Changes

1. useState -> useRef
 - React Native official site recommend using `useRef` instead of `useState` when you try to modifying the animated value.
   You can Check [here](https://reactnative.dev/docs/animated).

2. `useNativeDriver: true`
 - As updated to `expo SDK 38`, React native version was also updated to `0.62`. So we don't need platform based conditional statement anymore.

... and some minor changes

It can be operated in all platforms(ios, android, web).

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
