### PR TITLE
[bugfix/accordion] first rotate Animation not Working

### DIFF
--- a/main/Accordion/AccordionItem.tsx
+++ b/main/Accordion/AccordionItem.tsx
@@ -5,6 +5,7 @@ import {
   ViewStyle,
 } from 'react-native';
 import React, { FC, useEffect, useRef, useState } from 'react';
+
 import styled from 'styled-components/native';
 
 const Container = styled.View`
@@ -81,7 +82,7 @@ const AccordionItem: FC<Props> = (props) => {
   const rotateAnimValue = useRef(new Animated.Value(0)).current;
 
   const [opened, setItemVisible] = useState<boolean>(collapseOnStart);
-  const [rotateState, setRotateState] = useState<boolean>(false);
+  const [rotateState, setRotateState] = useState<boolean>(true);
   const [bodyMounted, setBodyMounted] = useState<boolean>(false);
 
   const [bodyHeight, setBodyHeight] = useState<number>(1);


### PR DESCRIPTION
## Description
Accordion components 
first rotate Animation not Working

before
![before](https://user-images.githubusercontent.com/34743425/87245619-b08bd200-c481-11ea-98a0-799607724ef7.gif)

after
![after](https://user-images.githubusercontent.com/34743425/87245622-b97ca380-c481-11ea-87c4-18309e558869.gif)

[AccordionItem.tsx]
```tsx
...
  useEffect(() => {
    const targetValue = opened ? 0 : 1;
    Animated.timing(rotateAnimValue, {
      toValue: targetValue,
      duration: 200,
      easing: Easing.linear,
      useNativeDriver: true,
    }).start();
  }, [rotateState]);
```
The initial value of rotateState is false.
However, it only works when the rotateState value changes in the first rotation animation.
so it doesn't work at first
## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [X] Run `yarn lint`
- [X] I am willing to follow-up on review comments in a timely manner.
