### PR TITLE
Add RTL option to SwitchToggle props

### DIFF
--- a/main/SwitchToggle/README.md
+++ b/main/SwitchToggle/README.md
@@ -28,6 +28,7 @@
 | buttonContainerStyle |           | `StyleProp<ViewStyle>` | Styles for button container                              |
 | rightContainerStyle  |           | `StyleProp<ViewStyle>` | Styles for right text container                          |
 | leftContainerStyle   |           | `StyleProp<ViewStyle>` | Styles for left text container                           |
+| RTL                  |           | boolean                | false                                                    |
 
 ## Installation
 

--- a/main/SwitchToggle/index.tsx
+++ b/main/SwitchToggle/index.tsx
@@ -32,6 +32,7 @@ interface Props {
   buttonContainerStyle?: StyleProp<ViewStyle> | any;
   rightContainerStyle?: StyleProp<ViewStyle> | any;
   leftContainerStyle?: StyleProp<ViewStyle> | any;
+  RTL?: boolean;
 }
 
 const styles = StyleSheet.create({
@@ -70,7 +71,7 @@ function SwitchToggle(props: Props): React.ReactElement {
         ((props.circleStyle.width as number) +
           (props.containerStyle.padding as number || 0) * 2)
       : 0;
-  const circlePosXEnd = endPos;
+  const circlePosXEnd = props.RTL ? -endPos : endPos;
   const [circlePosXStart] = useState(getStart());
 
   const prevSwitchOnRef = useRef<boolean>();


### PR DESCRIPTION
## Description

SwitchToggle works like below if you change the language of Android phones to Hebrew.
![hebrew](https://user-images.githubusercontent.com/17980230/87950970-f7617380-cae2-11ea-9581-c385f4b51e41.gif)

To support RTL, as @anaskhraza said at [this issue](https://github.com/dooboolab/dooboo-ui/issues/210), I added the RTL option to the props and multiplied circlePosXEnd by -1 if the props.RTL is true.
![RTL-hebrew](https://user-images.githubusercontent.com/17980230/87950977-f9c3cd80-cae2-11ea-90a8-d949c2289016.gif)


## Related Issues

#210 

## Tests

Skipped.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
