### PR TITLE
Add postbuild script for building storybook

### DIFF
--- a/doc/package.json
+++ b/doc/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "start": "start-storybook --docs -p 9001 -c ./.storybook",
-    "build": "yarn && build-storybook --docs -o ../doc-build -c ./.storybook"
+    "build": "yarn && build-storybook --docs -o ../doc-build -c ./.storybook",
+    "postbuild": "sh postbuild.sh"
   }
 }

--- a/doc/postbuild.sh
+++ b/doc/postbuild.sh
@@ -1,0 +1,1 @@
+sed -i "s/\"\//\"/g" ../doc-build/iframe.html


### PR DESCRIPTION
## Description

When building a storybook, the `iframe.html` link is broken since that all starts with absolute path `/app.js...`.

I've added shell script to `postbuild` script so it will replace the wrong `src` strings in `iframe.html`.

The issue was resolved by @s-ong-c.

## Related issue

https://github.com/storybookjs/storybook/issues/11694

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
