### PR TITLE
Change box type to show signIn style and add 1 props which is contentStyle

### DIFF
--- a/main/EditText/README.md
+++ b/main/EditText/README.md
@@ -6,8 +6,8 @@
 
 | | Default | Row |
 |--|---------------|--------------|
-| `underlined` |![underlined_default](https://user-images.githubusercontent.com/31176502/71721202-8bc9f880-2e67-11ea-8ffd-b6bf81814a26.gif) | ![underlined_row](https://user-images.githubusercontent.com/31176502/71721235-ad2ae480-2e67-11ea-914f-dc74ea4c6e7f.gif) |
-| <center>`box`</center> |![default](https://user-images.githubusercontent.com/31176502/71764827-4b827d00-2f30-11ea-85dd-887b218afeec.gif) | ![row](https://user-images.githubusercontent.com/31176502/71720737-1873b700-2e66-11ea-9b6b-1cdc175cbc0a.gif) |
+| `underlined` |![underlined_default](https://user-images.githubusercontent.com/58724686/88875168-bcd2a600-d25b-11ea-9d17-7ae71c200e21.png) | ![underlined_row](https://user-images.githubusercontent.com/58724686/88875181-c22ff080-d25b-11ea-9c9b-5c9a847f96fe.png) |
+| <center>`box`</center> |![default](https://user-images.githubusercontent.com/58724686/88875188-c52ae100-d25b-11ea-8f52-be578d72737d.png) | ![row](https://user-images.githubusercontent.com/58724686/88875196-c9ef9500-d25b-11ea-82b6-bb15111eba53.png) |
 
 ## Props
 
@@ -27,6 +27,7 @@
 | borderColor          |           | string                 |       `#eaeaf9`      |
 | inputLeftMargin      |           | number                 |         `110`        |
 | textStyle            |           | `TextStyle`            |                      |
+| contentStyle         |           | `ViewStyle`            |                      |
 | placeholder          |           | string                 |                      |
 | placeholderTextColor |           | string                 |                      |
 | secureTextEntry      |           | boolean                |                      |
@@ -54,86 +55,115 @@ yarn add dooboo-ui
 
 - Import
 
-  ```javascript
-  import { EditText } from 'dooboo-ui';
-  ```
+```javascript
+import { EditText } from 'dooboo-ui';
+```
 
 - Usage
 
-  ```javascript
-  function Page(props: Props) {
-    const validateEmail = (email: string) => {
-      const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-      return re.test(email);
-    };
+```javascript
+const Default = (): React.ReactElement => {
+  const validateEmail = (email: string): boolean => {
+    const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return re.test(email);
+  };
 
-    const fontStyle: TextStyle = {
-      fontWeight: 'bold',
-      fontSize: 13,
-    };
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [errorEmail, setErrorEmail] = useState<string>('');
 
-    const [email, setEmail] = useState('');
-    const [password, setPassword] = useState('');
-    const [errorEmail, setErrorEmail] = useState('');
+  const onSignIn = (): void => {
+    if (!validateEmail(email)) {
+      setErrorEmail('Not a valid email address');
+    }
+  };
 
-    const onSignIn = () => {
-      if (!validateEmail(email)) {
-        setErrorEmail('Not a valid email address');
-      } else {
-        setErrorEmail('');
-      }
-    };
+  const onTextChanged = (type: string, text: string): void => {
+    type === 'EMAIL' ? setEmail(text) : setPassword(text);
 
-    const onTextChanged = (type: string, text: string) => {
-      type === 'EMAIL' ? setEmail(text) : setPassword(text);
+    if (type === 'EMAIL' && text === '') {
+      setErrorEmail('');
+    }
+  };
 
-      if (type === 'EMAIL' && text === '') {
-        setErrorEmail('');
-      }
-    };
-
-    return (
-      <StyledScrollView
+  return (
+    <SafeAreaView>
+      <ScrollView
         contentContainerStyle={{
           marginTop: 8,
+          alignSelf: 'stretch',
           paddingHorizontal: 20,
-          paddingBottom: 40,
+          paddingVertical: 100,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
         }}
       >
-        <Container>
-          <HeaderTitle>Sign in with Email</HeaderTitle>
+        <View
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            width: Platform.OS === 'web' ? 438 : '100%',
+          }}
+        >
+          <Text
+            style={{
+              fontWeight: 'bold',
+              fontSize: 24,
+              lineHeight: 35,
+              color: '#495057',
+            }}>
+            Sign in with Email
+          </Text>
           <EditText
-            testID="EMAIL_INPUT"
+            testID="EMAIL_INPUT_DEFAULT"
             textStyle={{
               color: '#495057',
             }}
             label="Email"
-            placeholder="Write email address"
+            placeholder="Email address"
             placeholderTextColor="#ADB5BD"
             value={email}
-            onChangeText={(text: string) => onTextChanged('EMAIL', text)}
-            style={{ marginTop: 50 }}
+            onChangeText={(text: string): void => onTextChanged('EMAIL', text)}
+            style={{ 
+              marginTop: 50 
+            }}
             errorText={errorEmail}
             onSubmitEditing={onSignIn}
           />
           <EditText
-            testID="PASSWORD_INPUT"
+            testID="PASSWORD_INPUT_DEFAULT"
             textStyle={{
               color: '#ADB5BD',
             }}
             secureTextEntry={true}
             label="Password"
-            placeholder="Please write your password"
+            placeholder="Your password"
             placeholderTextColor="#ADB5BD"
             value={password}
-            onChangeText={(text: string) => onTextChanged('PASSWORD', text)}
+            onChangeText={(text: string): void =>
+              onTextChanged('PASSWORD', text)
+            }
             style={{ marginTop: 36 }}
             onSubmitEditing={onSignIn}
           />
-          <StyledSignInButton
-            testID="btnEmail"
-            onPress={() => onSignIn()}
-            textStyle={fontStyle}
+          <Button
+            style={{
+              borderRadius: 6,
+              borderWidth: 0,
+              marginTop: 40,
+              width: 184,
+              height: 48,
+              backgroundColor: '#6DA6FC',
+            }}
+            testID="BTN_DEFAULT"
+            onPress={(): void => onSignIn()}
+            textStyle={{
+              color: '#FFFFFF',
+            }}
             text="Login"
           />
           {/* Email SignUp text */}
@@ -145,15 +175,29 @@ yarn add dooboo-ui
               alignItems: 'center',
             }}
           >
-            <StyledText testID="NO_ACCOUNT">
+            <Text
+              testID="NO_ACCOUNT"
+              style={{
+                fontSize: 14,
+                color: '#495057',
+              }}
+            >
               Do not have and account?{' '}
-            </StyledText>
-            <TouchableOpacity onPress={() => null} style={{ padding: 4 }}>
-              <StyledAccentText>Find</StyledAccentText>
+            </Text>
+            <TouchableOpacity onPress={(): null => null} style={{ padding: 4 }}>
+              <Text
+                style={{
+                  color: '#6772e5',
+                  fontWeight: 'bold',
+                }}
+              >
+                Find
+              </Text>
             </TouchableOpacity>
           </View>
-        </Container>
-      </StyledScrollView>
-    );
-  }
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
   ```

--- a/main/EditText/README.md
+++ b/main/EditText/README.md
@@ -55,13 +55,13 @@ yarn add dooboo-ui
 
 - Import
 
-```javascript
+```typescript
 import { EditText } from 'dooboo-ui';
 ```
 
 - Usage
 
-```javascript
+```typescript
 const Default = (): React.ReactElement => {
   const validateEmail = (email: string): boolean => {
     const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -119,7 +119,7 @@ const Default = (): React.ReactElement => {
             Sign in with Email
           </Text>
           <EditText
-            testID="EMAIL_INPUT_DEFAULT"
+            testID="email-input-defualt"
             textStyle={{
               color: '#495057',
             }}
@@ -128,14 +128,14 @@ const Default = (): React.ReactElement => {
             placeholderTextColor="#ADB5BD"
             value={email}
             onChangeText={(text: string): void => onTextChanged('EMAIL', text)}
-            style={{ 
-              marginTop: 50 
+            style={{
+              marginTop: 50,
             }}
             errorText={errorEmail}
             onSubmitEditing={onSignIn}
           />
           <EditText
-            testID="PASSWORD_INPUT_DEFAULT"
+            testID="password-input-default"
             textStyle={{
               color: '#ADB5BD',
             }}
@@ -159,7 +159,7 @@ const Default = (): React.ReactElement => {
               height: 48,
               backgroundColor: '#6DA6FC',
             }}
-            testID="BTN_DEFAULT"
+            testID="btn-default"
             onPress={(): void => onSignIn()}
             textStyle={{
               color: '#FFFFFF',
@@ -176,7 +176,7 @@ const Default = (): React.ReactElement => {
             }}
           >
             <Text
-              testID="NO_ACCOUNT"
+              testID="no-account"
               style={{
                 fontSize: 14,
                 color: '#495057',
@@ -200,4 +200,4 @@ const Default = (): React.ReactElement => {
     </SafeAreaView>
   );
 };
-  ```
+```

--- a/main/EditText/index.tsx
+++ b/main/EditText/index.tsx
@@ -188,9 +188,10 @@ function EditText(props: Props): ReactElement {
               labelTextStyle,
               errorText
                 ? { color: errorColor }
-                : focused
-                  ? [{ color: focusColor }, focusedLabelStyle]
-                  : null,
+                : focused && [
+                  { color: focusColor },
+                  focusedLabelStyle,
+                ],
             ]}
           >
             {label}
@@ -217,22 +218,20 @@ function EditText(props: Props): ReactElement {
             onSubmitEditing={onSubmitEditing}
             multiline={multiline}
           />
-          {borderWidth ? (
-            <StyledLine
+          {
+            borderWidth && <StyledLine
               style={[
                 borderStyle,
                 { borderBottomWidth: borderWidth, borderColor: borderColor },
                 errorText
                   ? { borderColor: errorColor }
-                  : focused
-                    ? [
-                      { borderColor: focusColor },
-                      { borderBottomWidth: focusedBorderWidth },
-                    ]
-                    : null,
+                  : focused && [
+                    { borderColor: focusColor },
+                    { borderBottomWidth: focusedBorderWidth },
+                  ],
               ]}
             />
-          ) : null}
+          }
           {errorText ? (
             <StyledInvalidText
               testID={errorTestID}
@@ -254,12 +253,10 @@ function EditText(props: Props): ReactElement {
                   borderColor: errorColor,
                   borderBottomWidth: focusedBorderWidth,
                 }
-                : focused
-                  ? {
-                    borderColor: focusColor,
-                    borderBottomWidth: focusedBorderWidth,
-                  }
-                  : null,
+                : focused && {
+                  borderColor: focusColor,
+                  borderBottomWidth: focusedBorderWidth,
+                },
               contentStyle,
             ]}
           >
@@ -269,9 +266,10 @@ function EditText(props: Props): ReactElement {
                   labelTextStyle,
                   errorText
                     ? [{ color: errorColor }, focusedLabelStyle]
-                    : focused
-                      ? [{ color: focusColor }, focusedLabelStyle]
-                      : null,
+                    : focused && [
+                      { color: focusColor },
+                      focusedLabelStyle,
+                    ],
                   { width: labelWidth },
                 ]}
               >
@@ -322,9 +320,10 @@ function EditText(props: Props): ReactElement {
               labelTextStyle,
               errorText
                 ? { color: errorColor }
-                : focused
-                  ? [{ color: focusColor }, focusedLabelStyle]
-                  : null,
+                : focused && [
+                  { color: focusColor },
+                  focusedLabelStyle,
+                ],
             ]}
           >
             {label}
@@ -338,9 +337,10 @@ function EditText(props: Props): ReactElement {
               borderStyle,
               errorText
                 ? { borderColor: errorColor, borderWidth: focusedBorderWidth }
-                : focused
-                  ? { borderColor: focusColor, borderWidth: focusedBorderWidth }
-                  : null,
+                : focused && {
+                  borderColor: focusColor,
+                  borderWidth: focusedBorderWidth,
+                },
               contentStyle,
             ]}
           >
@@ -404,9 +404,10 @@ function EditText(props: Props): ReactElement {
               borderStyle,
               errorText
                 ? { borderColor: errorColor, borderWidth: focusedBorderWidth }
-                : focused
-                  ? { borderColor: focusColor, borderWidth: focusedBorderWidth }
-                  : null,
+                : focused && {
+                  borderColor: focusColor,
+                  borderWidth: focusedBorderWidth,
+                },
             ]}
           >
             {label ? (

--- a/main/EditText/index.tsx
+++ b/main/EditText/index.tsx
@@ -160,7 +160,6 @@ function EditText(props: Props): ReactElement {
     secureTextEntry,
     onChangeText,
     onSubmitEditing,
-
     rightElement,
     rightElementStyle,
     focusedLabelStyle = { fontWeight: 'bold' },

--- a/main/EditText/index.tsx
+++ b/main/EditText/index.tsx
@@ -260,7 +260,7 @@ function EditText(props: Props): ReactElement {
                     borderBottomWidth: focusedBorderWidth,
                   }
                   : null,
-                  contentStyle,
+              contentStyle,
             ]}
           >
             {label ? (
@@ -341,7 +341,7 @@ function EditText(props: Props): ReactElement {
                 : focused
                   ? { borderColor: focusColor, borderWidth: focusedBorderWidth }
                   : null,
-                  contentStyle,
+              contentStyle,
             ]}
           >
             <StyledTextInput

--- a/main/EditText/index.tsx
+++ b/main/EditText/index.tsx
@@ -90,6 +90,7 @@ interface Props {
   labelTextStyle?: TextStyle;
   labelWidth?: number;
   value?: TextInputProps['value'];
+  contentStyle?: ViewStyle;
   inputContainerType?: string;
   inputContainerRadius?: number;
   borderStyle?: ViewStyle;
@@ -142,6 +143,7 @@ function EditText(props: Props): ReactElement {
     labelTextStyle,
     labelWidth = 110,
     value,
+    contentStyle,
     borderStyle,
     borderWidth = 0.6,
     borderColor = '#eaeaf9',
@@ -258,6 +260,7 @@ function EditText(props: Props): ReactElement {
                     borderBottomWidth: focusedBorderWidth,
                   }
                   : null,
+                  contentStyle,
             ]}
           >
             {label ? (
@@ -338,6 +341,7 @@ function EditText(props: Props): ReactElement {
                 : focused
                   ? { borderColor: focusColor, borderWidth: focusedBorderWidth }
                   : null,
+                  contentStyle,
             ]}
           >
             <StyledTextInput

--- a/main/__tests__/__snapshots__/EditText.test.tsx.snap
+++ b/main/__tests__/__snapshots__/EditText.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`[EditText] Type: [box] renders without crashing 1`] = `
           "marginBottom": 5,
         },
         undefined,
-        null,
+        false,
       ]
     }
   >
@@ -42,7 +42,7 @@ exports[`[EditText] Type: [box] renders without crashing 1`] = `
           "borderWidth": 0.6,
         },
         undefined,
-        null,
+        false,
         undefined,
       ]
     }
@@ -96,7 +96,7 @@ exports[`[EditText] Type: [default] renders without crashing 1`] = `
           "marginBottom": 5,
         },
         undefined,
-        null,
+        false,
       ]
     }
   >
@@ -138,7 +138,7 @@ exports[`[EditText] Type: [default] renders without crashing 1`] = `
           "borderBottomWidth": 0.6,
           "borderColor": "#eaeaf9",
         },
-        null,
+        false,
       ]
     }
   />
@@ -170,7 +170,7 @@ exports[`[EditText] Type: [row] renders without crashing 1`] = `
           "borderColor": "#eaeaf9",
         },
         undefined,
-        null,
+        false,
         undefined,
       ]
     }
@@ -235,7 +235,7 @@ exports[`[EditText] Type: [rowBox] renders without crashing 1`] = `
           "borderWidth": 0.6,
         },
         undefined,
-        null,
+        false,
       ]
     }
   >

--- a/main/__tests__/__snapshots__/EditText.test.tsx.snap
+++ b/main/__tests__/__snapshots__/EditText.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`[EditText] Type: [box] renders without crashing 1`] = `
         },
         undefined,
         null,
+        undefined,
       ]
     }
   >
@@ -170,6 +171,7 @@ exports[`[EditText] Type: [row] renders without crashing 1`] = `
         },
         undefined,
         null,
+        undefined,
       ]
     }
   >

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint main packages stories --ext .ts,.tsx,.js,.jsx",
     "tsc": "tsc",
     "start": "expo start",
+    "jest": "jest",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "start-storybook -p 6006",

--- a/stories/dooboo-ui/EditText.stories.tsx
+++ b/stories/dooboo-ui/EditText.stories.tsx
@@ -1,13 +1,13 @@
 import EditText, { EditTextInputType } from '../../main/EditText';
 import {
   Image,
+  Platform,
   SafeAreaView,
   ScrollView,
   Text,
   TextStyle,
   TouchableOpacity,
   View,
-  Platform,
 } from 'react-native';
 import React, { ReactElement, useState } from 'react';
 
@@ -67,7 +67,7 @@ const Default = (): React.ReactElement => {
             alignItems: 'center',
             padding: 20,
             paddingTop: 10,
-            width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+            width: `${Platform.OS === 'web' ? 438 : '100%'}`,
           }}
         >
           <Text
@@ -203,7 +203,7 @@ const RowEditText = (): React.ReactElement => {
             alignItems: 'center',
             padding: 20,
             paddingTop: 10,
-            width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+            width: `${Platform.OS === 'web' ? 438 : '100%'}`,
           }}
         >
           <Text
@@ -366,7 +366,7 @@ const BoxEditText = (): React.ReactElement => {
             alignItems: 'center',
             padding: 20,
             paddingTop: 10,
-            width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+            width: `${Platform.OS === 'web' ? 438 : '100%'}`,
           }}
         >
           <Text
@@ -403,7 +403,7 @@ const BoxEditText = (): React.ReactElement => {
             onChangeText={(text: string): void => onTextChanged('EMAIL', text)}
             style={{
               marginTop: 30,
-              width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+              width: `${Platform.OS === 'web' ? 438 : '100%'}`,
             }}
             contentStyle={{
               paddingHorizontal: 16,
@@ -444,7 +444,7 @@ const BoxEditText = (): React.ReactElement => {
             }
             style={{
               marginTop: 20,
-              width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+              width: `${Platform.OS === 'web' ? 438 : '100%'}`,
             }}
             contentStyle={{
               paddingHorizontal: 16,
@@ -478,7 +478,7 @@ const BoxEditText = (): React.ReactElement => {
             placeholderTextColor="#707683"
             style={{
               marginTop: 20,
-              width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+              width: `${Platform.OS === 'web' ? 438 : '100%'}`,
             }}
             contentStyle={{
               paddingHorizontal: 16,
@@ -566,7 +566,7 @@ const BoxRowEditText = (): React.ReactElement => {
             alignItems: 'center',
             padding: 20,
             paddingTop: 10,
-            width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+            width: `${Platform.OS === 'web' ? 438 : '100%'}`,
           }}
         >
           <Text

--- a/stories/dooboo-ui/EditText.stories.tsx
+++ b/stories/dooboo-ui/EditText.stories.tsx
@@ -1,5 +1,4 @@
 import EditText, { EditTextInputType } from '../../main/EditText';
-import { IC_CHECK, IC_EDIT } from '../Icon';
 import {
   Image,
   SafeAreaView,
@@ -8,11 +7,13 @@ import {
   TextStyle,
   TouchableOpacity,
   View,
+  Platform,
 } from 'react-native';
 import React, { ReactElement, useState } from 'react';
 
 import Button from '../../main/Button';
 import { ContainerDeco } from '../../storybook/decorators';
+import { IC_CHECK } from '../Icon';
 import { storiesOf } from '@storybook/react-native';
 
 const Default = (): React.ReactElement => {
@@ -52,14 +53,23 @@ const Default = (): React.ReactElement => {
           alignSelf: 'stretch',
           paddingHorizontal: 20,
           paddingVertical: 100,
-        }}>
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
         <View
           style={{
             display: 'flex',
             flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
             padding: 20,
             paddingTop: 10,
-          }}>
+            width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+          }}
+        >
           <Text
             style={{
               fontWeight: 'bold',
@@ -104,7 +114,7 @@ const Default = (): React.ReactElement => {
               borderRadius: 26,
               borderWidth: 0,
               marginTop: 40,
-              width: '100%',
+              width: 184,
               backgroundColor: 'rgb(36, 205, 151)',
             }}
             testID="btnEmail"
@@ -119,13 +129,15 @@ const Default = (): React.ReactElement => {
               flexDirection: 'row',
               justifyContent: 'center',
               alignItems: 'center',
-            }}>
+            }}
+          >
             <Text
               testID="NO_ACCOUNT"
               style={{
                 fontSize: 14,
                 color: '#495057',
-              }}>
+              }}
+            >
               Do not have and account?{' '}
             </Text>
             <TouchableOpacity onPress={(): null => null} style={{ padding: 4 }}>
@@ -133,7 +145,8 @@ const Default = (): React.ReactElement => {
                 style={{
                   color: '#6772e5',
                   fontWeight: 'bold',
-                }}>
+                }}
+              >
                 Find
               </Text>
             </TouchableOpacity>
@@ -175,22 +188,32 @@ const RowEditText = (): React.ReactElement => {
           marginTop: 8,
           alignSelf: 'stretch',
           paddingHorizontal: 20,
-          paddingVertical: 100,
-        }}>
+          paddingVertical: 30,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
         <View
           style={{
-            flex: 1,
+            display: 'flex',
             flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
             padding: 20,
             paddingTop: 10,
-          }}>
+            width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+          }}
+        >
           <Text
             style={{
               fontWeight: 'bold',
               fontSize: 24,
               lineHeight: 35,
               color: '#495057',
-            }}>
+            }}
+          >
             Sign in with Email
           </Text>
           <EditText
@@ -200,7 +223,7 @@ const RowEditText = (): React.ReactElement => {
             value={email}
             numberOfLines={1}
             style={{
-              marginTop: 180,
+              marginTop: 50,
             }}
             onBlur={(): void => {
               if (!validateEmail(email)) {
@@ -239,7 +262,7 @@ const RowEditText = (): React.ReactElement => {
               setPasswordErrorText('');
               setPassword(text);
             }}
-            placeholder="Write password."
+            placeholder="Write password"
             secureTextEntry={true}
             onSubmitEditing={onSignIn}
             errorText={passwordErrorText}
@@ -252,7 +275,7 @@ const RowEditText = (): React.ReactElement => {
               borderRadius: 26,
               borderWidth: 0,
               marginTop: 40,
-              width: '100%',
+              width: 184,
               backgroundColor: 'rgb(36, 205, 151)',
             }}
             testID="btnEmail"
@@ -267,13 +290,15 @@ const RowEditText = (): React.ReactElement => {
               flexDirection: 'row',
               justifyContent: 'center',
               alignItems: 'center',
-            }}>
+            }}
+          >
             <Text
               testID="NO_ACCOUNT"
               style={{
                 fontSize: 14,
                 color: '#495057',
-              }}>
+              }}
+            >
               Do not have and account?{' '}
             </Text>
             <TouchableOpacity onPress={(): null => null} style={{ padding: 4 }}>
@@ -281,7 +306,8 @@ const RowEditText = (): React.ReactElement => {
                 style={{
                   color: '#6772e5',
                   fontWeight: 'bold',
-                }}>
+                }}
+              >
                 Find
               </Text>
             </TouchableOpacity>
@@ -296,11 +322,6 @@ const BoxEditText = (): React.ReactElement => {
   const validateEmail = (email: string): boolean => {
     const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return re.test(email);
-  };
-
-  const fontStyle: TextStyle = {
-    fontWeight: 'bold',
-    fontSize: 13,
   };
 
   const [email, setEmail] = useState<string>('');
@@ -330,106 +351,162 @@ const BoxEditText = (): React.ReactElement => {
           marginTop: 8,
           alignSelf: 'stretch',
           paddingHorizontal: 20,
-          paddingVertical: 100,
-        }}>
+          paddingVertical: 30,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
         <View
           style={{
-            flex: 1,
+            display: 'flex',
             flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
             padding: 20,
             paddingTop: 10,
+            width: `${Platform.OS === 'web' ? 438 : '100%' }`,
           }}
         >
           <Text
             style={{
+              fontStyle: 'normal',
               fontWeight: 'bold',
-              fontSize: 24,
-              lineHeight: 35,
-              color: '#495057',
+              fontSize: 32,
+              lineHeight: 47,
+              letterSpacing: -0.05,
+              color: '#323C47',
             }}
           >
-            Sign in with Email
+            Sign In
           </Text>
           <EditText
             testID="EMAIL_INPUT"
             type={EditTextInputType.BOX}
+            labelTextStyle= {{
+              color: '#333333',
+              fontSize: 14,
+              lineHeight: 24,
+            }}
+            focusedLabelStyle= {{
+              color: '#333333',
+            }}
+            inputContainerRadius={30}
             textStyle={{
               color: '#495057',
             }}
             label="Email"
             placeholder="Email address"
-            placeholderTextColor="#ADB5BD"
+            placeholderTextColor="#707683"
             value={email}
             onChangeText={(text: string): void => onTextChanged('EMAIL', text)}
-            style={{ marginTop: 50 }}
+            style={{
+              marginTop: 30,
+              width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+            }}
+            contentStyle={{
+              paddingHorizontal: 16,
+              paddingVertical: 8,
+            }}
             errorText={errorEmail}
             onSubmitEditing={onSignIn}
-            borderStyle={{ height: 60 }}
+            borderStyle={{
+              height: 60,
+              borderRadius: 4,
+              borderColor: '#ECF0F5',
+            }}
             borderWidth={1}
-            leftElement={<Image source={IC_EDIT} />}
-            rightElement={
-              <Image source={IC_CHECK} style={{ width: 16, height: 16 }} />
-            }
+            rightElement={<Image source={IC_CHECK} style={{ width: 16, height: 16 }} />}
           />
           <EditText
             testID="PASSWORD_INPUT"
             type={EditTextInputType.BOX}
+            labelTextStyle= {{
+              color: '#333333',
+              fontSize: 14,
+              lineHeight: 24,
+            }}
+            focusedLabelStyle= {{
+              color: '#333333',
+            }}
             inputContainerRadius={30}
             textStyle={{
-              color: '#ADB5BD',
+              color: '#495057',
             }}
             secureTextEntry={true}
             label="Password"
             placeholder="Write your password"
-            placeholderTextColor="#ADB5BD"
+            placeholderTextColor="#707683"
             value={password}
             onChangeText={(text: string): void =>
               onTextChanged('PASSWORD', text)
             }
-            style={{ marginTop: 36 }}
+            style={{
+              marginTop: 20,
+              width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+            }}
+            contentStyle={{
+              paddingHorizontal: 16,
+              paddingVertical: 8,
+            }}
             onSubmitEditing={onSignIn}
-            leftElement={<Image source={IC_EDIT} />}
-            leftElementStyle={{ width: 60 }}
+            borderStyle={{
+              height: 60,
+              borderRadius: 4,
+              borderColor: '#ECF0F5',
+            }}
+          />
+          <EditText
+            testID="PASSWORD_INPUT_CONFIRM"
+            type={EditTextInputType.BOX}
+            labelTextStyle= {{
+              color: '#333333',
+              fontSize: 14,
+              lineHeight: 24,
+            }}
+            focusedLabelStyle= {{
+              color: '#333333',
+            }}
+            inputContainerRadius={30}
+            textStyle={{
+              color: '#495057',
+            }}
+            secureTextEntry={true}
+            label="Password Confirm"
+            placeholder="Confirm password"
+            placeholderTextColor="#707683"
+            style={{
+              marginTop: 20,
+              width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+            }}
+            contentStyle={{
+              paddingHorizontal: 16,
+              paddingVertical: 8,
+            }}
+            onSubmitEditing={onSignIn}
+            borderStyle={{
+              height: 60,
+              borderRadius: 4,
+              borderColor: '#ECF0F5',
+            }}
           />
           <Button
             style={{
-              borderRadius: 26,
+              borderRadius: 6,
               borderWidth: 0,
               marginTop: 40,
-              width: '100%',
-              backgroundColor: 'rgb(36, 205, 151)',
+              width: 184,
+              height: 48,
+              backgroundColor: '#6DA6FC',
             }}
             testID="btnEmail"
             onPress={(): void => onSignIn()}
-            textStyle={fontStyle}
-            text="Login"
+            textStyle={{
+              color: '#FFFFFF',
+            }}
+            text="Verify Email"
           />
-          {/* Email SignUp text */}
-          <View
-            style={{
-              marginTop: 20,
-              flexDirection: 'row',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}>
-            <Text
-              testID="NO_ACCOUNT"
-              style={{
-                fontSize: 14,
-                color: '#495057',
-              }}>
-              Do not have and account?{' '}
-            </Text>
-            <TouchableOpacity onPress={(): null => null} style={{ padding: 4 }}>
-              <Text
-                style={{
-                  color: '#6772e5',
-                  fontWeight: 'bold',
-                }}>
-                Find
-              </Text>
-            </TouchableOpacity>
-          </View>
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -474,22 +551,32 @@ const BoxRowEditText = (): React.ReactElement => {
           marginTop: 8,
           alignSelf: 'stretch',
           paddingHorizontal: 20,
-          paddingVertical: 100,
-        }}>
+          paddingVertical: 30,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
         <View
           style={{
-            flex: 1,
+            display: 'flex',
             flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
             padding: 20,
             paddingTop: 10,
-          }}>
+            width: `${Platform.OS === 'web' ? 438 : '100%' }`,
+          }}
+        >
           <Text
             style={{
               fontWeight: 'bold',
               fontSize: 24,
               lineHeight: 35,
               color: '#495057',
-            }}>
+            }}
+          >
             Sign in with Email
           </Text>
           <EditText
@@ -531,7 +618,7 @@ const BoxRowEditText = (): React.ReactElement => {
               borderRadius: 26,
               borderWidth: 0,
               marginTop: 40,
-              width: '100%',
+              width: 184,
               backgroundColor: 'rgb(36, 205, 151)',
             }}
             testID="btnEmail"

--- a/stories/dooboo-ui/EditText.stories.tsx
+++ b/stories/dooboo-ui/EditText.stories.tsx
@@ -5,7 +5,6 @@ import {
   SafeAreaView,
   ScrollView,
   Text,
-  TextStyle,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -20,11 +19,6 @@ const Default = (): React.ReactElement => {
   const validateEmail = (email: string): boolean => {
     const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return re.test(email);
-  };
-
-  const fontStyle: TextStyle = {
-    fontWeight: 'bold',
-    fontSize: 13,
   };
 
   const [email, setEmail] = useState<string>('');
@@ -65,9 +59,7 @@ const Default = (): React.ReactElement => {
             flexDirection: 'column',
             justifyContent: 'center',
             alignItems: 'center',
-            padding: 20,
-            paddingTop: 10,
-            width: `${Platform.OS === 'web' ? 438 : '100%'}`,
+            width: Platform.OS === 'web' ? 438 : '100%',
           }}
         >
           <Text
@@ -80,7 +72,7 @@ const Default = (): React.ReactElement => {
             Sign in with Email
           </Text>
           <EditText
-            testID="EMAIL_INPUT"
+            testID="EMAIL_INPUT_DEFAULT"
             textStyle={{
               color: '#495057',
             }}
@@ -89,12 +81,14 @@ const Default = (): React.ReactElement => {
             placeholderTextColor="#ADB5BD"
             value={email}
             onChangeText={(text: string): void => onTextChanged('EMAIL', text)}
-            style={{ marginTop: 50 }}
+            style={{
+              marginTop: 50,
+            }}
             errorText={errorEmail}
             onSubmitEditing={onSignIn}
           />
           <EditText
-            testID="PASSWORD_INPUT"
+            testID="PASSWORD_INPUT_DEFAULT"
             textStyle={{
               color: '#ADB5BD',
             }}
@@ -111,15 +105,18 @@ const Default = (): React.ReactElement => {
           />
           <Button
             style={{
-              borderRadius: 26,
+              borderRadius: 6,
               borderWidth: 0,
               marginTop: 40,
               width: 184,
-              backgroundColor: 'rgb(36, 205, 151)',
+              height: 48,
+              backgroundColor: '#6DA6FC',
             }}
-            testID="btnEmail"
+            testID="BTN_DEFAULT"
             onPress={(): void => onSignIn()}
-            textStyle={fontStyle}
+            textStyle={{
+              color: '#FFFFFF',
+            }}
             text="Login"
           />
           {/* Email SignUp text */}
@@ -163,11 +160,6 @@ const RowEditText = (): React.ReactElement => {
     return re.test(email);
   };
 
-  const fontStyle: TextStyle = {
-    fontWeight: 'bold',
-    fontSize: 13,
-  };
-
   const [email, setEmail] = useState<string>('');
   const [emailErrorText, setEmailErrorText] = useState<string>('');
   const [passwordErrorText, setPasswordErrorText] = useState<string>('');
@@ -188,7 +180,7 @@ const RowEditText = (): React.ReactElement => {
           marginTop: 8,
           alignSelf: 'stretch',
           paddingHorizontal: 20,
-          paddingVertical: 30,
+          paddingVertical: 100,
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'center',
@@ -201,23 +193,23 @@ const RowEditText = (): React.ReactElement => {
             flexDirection: 'column',
             justifyContent: 'center',
             alignItems: 'center',
-            padding: 20,
-            paddingTop: 10,
-            width: `${Platform.OS === 'web' ? 438 : '100%'}`,
+            width: Platform.OS === 'web' ? 438 : '100%',
           }}
         >
           <Text
             style={{
+              fontStyle: 'normal',
               fontWeight: 'bold',
-              fontSize: 24,
-              lineHeight: 35,
-              color: '#495057',
+              fontSize: 32,
+              lineHeight: 47,
+              letterSpacing: -0.05,
+              color: '#323C47',
             }}
           >
             Sign in with Email
           </Text>
           <EditText
-            testID="EMAIL_INPUT"
+            testID="EMAIL_INPUT_ROW"
             errorTestID="EMAIL_INPUT_ERROR"
             type={EditTextInputType.ROW}
             value={email}
@@ -247,7 +239,7 @@ const RowEditText = (): React.ReactElement => {
             }}
           />
           <EditText
-            testID="PASSWORD_INPUT"
+            testID="PASSWORD_INPUT_ROW"
             errorTestID="PASSWORD_INPUT_ERROR"
             type={EditTextInputType.ROW}
             autoCapitalize="none"
@@ -272,15 +264,18 @@ const RowEditText = (): React.ReactElement => {
           />
           <Button
             style={{
-              borderRadius: 26,
+              borderRadius: 6,
               borderWidth: 0,
               marginTop: 40,
               width: 184,
-              backgroundColor: 'rgb(36, 205, 151)',
+              height: 48,
+              backgroundColor: '#6DA6FC',
             }}
-            testID="btnEmail"
+            testID="BTN_ROW"
             onPress={(): void => onSignIn()}
-            textStyle={fontStyle}
+            textStyle={{
+              color: '#FFFFFF',
+            }}
             text="Login"
           />
           {/* Email SignUp text */}
@@ -351,7 +346,7 @@ const BoxEditText = (): React.ReactElement => {
           marginTop: 8,
           alignSelf: 'stretch',
           paddingHorizontal: 20,
-          paddingVertical: 30,
+          paddingVertical: 100,
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'center',
@@ -364,9 +359,7 @@ const BoxEditText = (): React.ReactElement => {
             flexDirection: 'column',
             justifyContent: 'center',
             alignItems: 'center',
-            padding: 20,
-            paddingTop: 10,
-            width: `${Platform.OS === 'web' ? 438 : '100%'}`,
+            width: Platform.OS === 'web' ? 438 : '100%',
           }}
         >
           <Text
@@ -379,10 +372,10 @@ const BoxEditText = (): React.ReactElement => {
               color: '#323C47',
             }}
           >
-            Sign In
+            Sign Up
           </Text>
           <EditText
-            testID="EMAIL_INPUT"
+            testID="EMAIL_INPUT_BOX"
             type={EditTextInputType.BOX}
             labelTextStyle= {{
               color: '#333333',
@@ -403,7 +396,6 @@ const BoxEditText = (): React.ReactElement => {
             onChangeText={(text: string): void => onTextChanged('EMAIL', text)}
             style={{
               marginTop: 30,
-              width: `${Platform.OS === 'web' ? 438 : '100%'}`,
             }}
             contentStyle={{
               paddingHorizontal: 16,
@@ -420,7 +412,7 @@ const BoxEditText = (): React.ReactElement => {
             rightElement={<Image source={IC_CHECK} style={{ width: 16, height: 16 }} />}
           />
           <EditText
-            testID="PASSWORD_INPUT"
+            testID="PASSWORD_INPUT_BOX"
             type={EditTextInputType.BOX}
             labelTextStyle= {{
               color: '#333333',
@@ -444,7 +436,6 @@ const BoxEditText = (): React.ReactElement => {
             }
             style={{
               marginTop: 20,
-              width: `${Platform.OS === 'web' ? 438 : '100%'}`,
             }}
             contentStyle={{
               paddingHorizontal: 16,
@@ -500,7 +491,7 @@ const BoxEditText = (): React.ReactElement => {
               height: 48,
               backgroundColor: '#6DA6FC',
             }}
-            testID="btnEmail"
+            testID="BTN_BOX"
             onPress={(): void => onSignIn()}
             textStyle={{
               color: '#FFFFFF',
@@ -517,11 +508,6 @@ const BoxRowEditText = (): React.ReactElement => {
   const validateEmail = (email: string): boolean => {
     const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return re.test(email);
-  };
-
-  const fontStyle: TextStyle = {
-    fontWeight: 'bold',
-    fontSize: 13,
   };
 
   const [email, setEmail] = useState<string>('');
@@ -551,7 +537,7 @@ const BoxRowEditText = (): React.ReactElement => {
           marginTop: 8,
           alignSelf: 'stretch',
           paddingHorizontal: 20,
-          paddingVertical: 30,
+          paddingVertical: 100,
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'center',
@@ -564,23 +550,23 @@ const BoxRowEditText = (): React.ReactElement => {
             flexDirection: 'column',
             justifyContent: 'center',
             alignItems: 'center',
-            padding: 20,
-            paddingTop: 10,
-            width: `${Platform.OS === 'web' ? 438 : '100%'}`,
+            width: Platform.OS === 'web' ? 438 : '100%',
           }}
         >
           <Text
             style={{
+              fontStyle: 'normal',
               fontWeight: 'bold',
-              fontSize: 24,
-              lineHeight: 35,
-              color: '#495057',
+              fontSize: 32,
+              lineHeight: 47,
+              letterSpacing: -0.05,
+              color: '#323C47',
             }}
           >
             Sign in with Email
           </Text>
           <EditText
-            testID="EMAIL_INPUT"
+            testID="EMAIL_INPUT_BOXROW"
             type="rowBox"
             textStyle={{
               color: '#495057',
@@ -590,13 +576,17 @@ const BoxRowEditText = (): React.ReactElement => {
             placeholderTextColor="#ADB5BD"
             value={email}
             onChangeText={(text: string): void => onTextChanged('EMAIL', text)}
-            style={{ marginTop: 50 }}
+            style={{
+              marginTop: 50,
+            }}
             errorText={errorEmail}
             onSubmitEditing={onSignIn}
-            borderStyle={{ height: 60 }}
+            borderStyle={{
+              height: 60,
+            }}
           />
           <EditText
-            testID="PASSWORD_INPUT"
+            testID="PASSWORD_INPUT_BOXROW"
             type={EditTextInputType.ROW_BOX}
             inputContainerRadius={25}
             textStyle={{
@@ -610,21 +600,26 @@ const BoxRowEditText = (): React.ReactElement => {
             onChangeText={(text: string): void =>
               onTextChanged('PASSWORD', text)
             }
-            style={{ marginTop: 36 }}
+            style={{
+              marginTop: 36,
+            }}
             onSubmitEditing={onSignIn}
           />
           <Button
             style={{
-              borderRadius: 26,
+              borderRadius: 6,
               borderWidth: 0,
               marginTop: 40,
               width: 184,
-              backgroundColor: 'rgb(36, 205, 151)',
+              height: 48,
+              backgroundColor: '#6DA6FC',
             }}
-            testID="btnEmail"
+            testID="BTN_BOXROW"
             onPress={(): void => onSignIn()}
-            textStyle={fontStyle}
-            text="Login"
+            textStyle={{
+              color: '#FFFFFF',
+            }}
+            text="SignIn"
           />
           <View
             style={{

--- a/stories/dooboo-ui/EditText.stories.tsx
+++ b/stories/dooboo-ui/EditText.stories.tsx
@@ -72,7 +72,7 @@ const Default = (): React.ReactElement => {
             Sign in with Email
           </Text>
           <EditText
-            testID="EMAIL_INPUT_DEFAULT"
+            testID="email-input-defualt"
             textStyle={{
               color: '#495057',
             }}
@@ -88,7 +88,7 @@ const Default = (): React.ReactElement => {
             onSubmitEditing={onSignIn}
           />
           <EditText
-            testID="PASSWORD_INPUT_DEFAULT"
+            testID="password-input-default"
             textStyle={{
               color: '#ADB5BD',
             }}
@@ -112,7 +112,7 @@ const Default = (): React.ReactElement => {
               height: 48,
               backgroundColor: '#6DA6FC',
             }}
-            testID="BTN_DEFAULT"
+            testID="btn-default"
             onPress={(): void => onSignIn()}
             textStyle={{
               color: '#FFFFFF',
@@ -129,7 +129,7 @@ const Default = (): React.ReactElement => {
             }}
           >
             <Text
-              testID="NO_ACCOUNT"
+              testID="no-account"
               style={{
                 fontSize: 14,
                 color: '#495057',
@@ -209,8 +209,8 @@ const RowEditText = (): React.ReactElement => {
             Sign in with Email
           </Text>
           <EditText
-            testID="EMAIL_INPUT_ROW"
-            errorTestID="EMAIL_INPUT_ERROR"
+            testID="email-input-row"
+            errorTestID="email-input-error"
             type={EditTextInputType.ROW}
             value={email}
             numberOfLines={1}
@@ -239,8 +239,8 @@ const RowEditText = (): React.ReactElement => {
             }}
           />
           <EditText
-            testID="PASSWORD_INPUT_ROW"
-            errorTestID="PASSWORD_INPUT_ERROR"
+            testID="password-input-row"
+            errorTestID="password-input-error"
             type={EditTextInputType.ROW}
             autoCapitalize="none"
             style={{
@@ -271,7 +271,7 @@ const RowEditText = (): React.ReactElement => {
               height: 48,
               backgroundColor: '#6DA6FC',
             }}
-            testID="BTN_ROW"
+            testID="btn-row"
             onPress={(): void => onSignIn()}
             textStyle={{
               color: '#FFFFFF',
@@ -288,7 +288,7 @@ const RowEditText = (): React.ReactElement => {
             }}
           >
             <Text
-              testID="NO_ACCOUNT"
+              testID="no-account"
               style={{
                 fontSize: 14,
                 color: '#495057',
@@ -375,7 +375,7 @@ const BoxEditText = (): React.ReactElement => {
             Sign Up
           </Text>
           <EditText
-            testID="EMAIL_INPUT_BOX"
+            testID="email-input-box"
             type={EditTextInputType.BOX}
             labelTextStyle= {{
               color: '#333333',
@@ -412,7 +412,7 @@ const BoxEditText = (): React.ReactElement => {
             rightElement={<Image source={IC_CHECK} style={{ width: 16, height: 16 }} />}
           />
           <EditText
-            testID="PASSWORD_INPUT_BOX"
+            testID="password-input-box"
             type={EditTextInputType.BOX}
             labelTextStyle= {{
               color: '#333333',
@@ -449,7 +449,7 @@ const BoxEditText = (): React.ReactElement => {
             }}
           />
           <EditText
-            testID="PASSWORD_INPUT_CONFIRM"
+            testID="password-input-confirm"
             type={EditTextInputType.BOX}
             labelTextStyle= {{
               color: '#333333',
@@ -491,7 +491,7 @@ const BoxEditText = (): React.ReactElement => {
               height: 48,
               backgroundColor: '#6DA6FC',
             }}
-            testID="BTN_BOX"
+            testID="btn-box"
             onPress={(): void => onSignIn()}
             textStyle={{
               color: '#FFFFFF',
@@ -566,7 +566,7 @@ const BoxRowEditText = (): React.ReactElement => {
             Sign in with Email
           </Text>
           <EditText
-            testID="EMAIL_INPUT_BOXROW"
+            testID="email-input-boxrow"
             type="rowBox"
             textStyle={{
               color: '#495057',
@@ -586,7 +586,7 @@ const BoxRowEditText = (): React.ReactElement => {
             }}
           />
           <EditText
-            testID="PASSWORD_INPUT_BOXROW"
+            testID="password-input-boxrow"
             type={EditTextInputType.ROW_BOX}
             inputContainerRadius={25}
             textStyle={{
@@ -614,7 +614,7 @@ const BoxRowEditText = (): React.ReactElement => {
               height: 48,
               backgroundColor: '#6DA6FC',
             }}
-            testID="BTN_BOXROW"
+            testID="btn-boxrow"
             onPress={(): void => onSignIn()}
             textStyle={{
               color: '#FFFFFF',
@@ -629,7 +629,7 @@ const BoxRowEditText = (): React.ReactElement => {
               alignItems: 'center',
             }}>
             <Text
-              testID="NO_ACCOUNT"
+              testID="no-account"
               style={{
                 fontSize: 14,
                 color: '#495057',


### PR DESCRIPTION
## Description

Change box type to show signIn style and add 1 props which is contentStyle.
I'm checking style on web, ios, android and storybook.
And I will update README.md file If this PR should be merged.

The new style shows below.
![image](https://user-images.githubusercontent.com/58724686/88749111-93e3df80-d18d-11ea-8c41-a0c5acada1b3.png)

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
