### PR TITLE
Fixed to storybook link is broken for building storybook

### DIFF
--- a/doc/.storybook/webpack.config.js
+++ b/doc/.storybook/webpack.config.js
@@ -37,8 +37,10 @@ module.exports = ({ config, mode }) => {
   config.resolve.alias = {
     'react-native': 'react-native-web',
   };
+  
 
-  return withUnimodules(config, {
+  const wUni = withUnimodules(config, 
+    {
     projectRoot: resolve(__dirname, '../'),
     // babel: {
     //   dangerouslyAddModulePathsToTranspile: [
@@ -47,4 +49,6 @@ module.exports = ({ config, mode }) => {
     //   ],
     // },
   });
+  wUni.output.publicPath = ''
+  return wUni
 };

--- a/doc/.storybook/webpack.config.js
+++ b/doc/.storybook/webpack.config.js
@@ -37,10 +37,8 @@ module.exports = ({ config, mode }) => {
   config.resolve.alias = {
     'react-native': 'react-native-web',
   };
-  
 
-  const wUni = withUnimodules(config, 
-    {
+  const configWithExpo = withUnimodules(config, {
     projectRoot: resolve(__dirname, '../'),
     // babel: {
     //   dangerouslyAddModulePathsToTranspile: [
@@ -49,6 +47,6 @@ module.exports = ({ config, mode }) => {
     //   ],
     // },
   });
-  wUni.output.publicPath = ''
-  return wUni
+  configWithExpo.output.publicPath = '';
+  return configWithExpo;
 };

--- a/doc/package.json
+++ b/doc/package.json
@@ -27,7 +27,6 @@
   },
   "scripts": {
     "start": "start-storybook --docs -p 9001 -c ./.storybook",
-    "build": "yarn && build-storybook --docs -o ../doc-build -c ./.storybook",
-    "postbuild": "sh postbuild.sh"
+    "build": "yarn && build-storybook --docs -o ../doc-build -c ./.storybook"
   }
 }

--- a/doc/postbuild.sh
+++ b/doc/postbuild.sh
@@ -1,1 +1,0 @@
-sed -i "s/\"\//\"/g" ../doc-build/iframe.html


### PR DESCRIPTION
## Description
When building a storybook, the iframe.html link is broken since that all starts with absolute path /app.js....
I've fixed webpack.config.js file so it will correct

previous solution
  Add postbuild script for building storybook #259

current solution (thx to @ndelangen @Marklb)
  fixed webpack.config.js

## Related Issues
[https://github.com/storybookjs/storybook/issues/11694](https://github.com/storybookjs/storybook/issues/11694)

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
