### PR TITLE
fix: correct text input password ellipsis issue

### DIFF
--- a/main/EditText/index.tsx
+++ b/main/EditText/index.tsx
@@ -11,11 +11,6 @@ import React, { FC, ReactElement, useState } from 'react';
 
 import styled from 'styled-components/native';
 
-const RowContainer = styled.View`
-  flex-direction: column;
-  align-self: stretch;
-`;
-
 const StyledRowContent = styled.View`
   flex-direction: row;
   align-items: center;
@@ -40,8 +35,7 @@ const StyledRowInput = styled.TextInput`
   ${Platform.OS === 'web' && { 'outline-style': 'none' }}
 `;
 
-const ColumnContainer = styled.View`
-  display: flex;
+const Container = styled.View`
   flex-direction: column;
   align-self: stretch;
 `;
@@ -69,6 +63,7 @@ const StyledTextInput = styled.TextInput`
   padding-bottom: 15px;
   font-size: 15px;
   font-weight: 500;
+  flex: 1;
   ${Platform.OS === 'web' && { 'outline-style': 'none' }}
 `;
 
@@ -181,7 +176,7 @@ const EditText: FC<Props> = (props) => {
     case EditTextInputType.DEFAULT:
     default:
       return (
-        <ColumnContainer style={style}>
+        <Container style={style}>
           <StyledLabel
             style={[
               labelTextStyle,
@@ -238,11 +233,11 @@ const EditText: FC<Props> = (props) => {
               {`${errorText}`}
             </StyledInvalidText>
           ) : null}
-        </ColumnContainer>
+        </Container>
       );
     case EditTextInputType.ROW:
       return (
-        <RowContainer style={style}>
+        <Container style={style}>
           <StyledRowContent
             style={[
               { borderColor: borderColor, borderBottomWidth: borderWidth },
@@ -308,12 +303,12 @@ const EditText: FC<Props> = (props) => {
               {errorText}
             </StyledInvalidText>
           ) : null}
-        </RowContainer>
+        </Container>
       );
 
     case EditTextInputType.BOX:
       return (
-        <ColumnContainer style={style}>
+        <Container style={style}>
           <StyledLabel
             style={[
               labelTextStyle,
@@ -388,12 +383,12 @@ const EditText: FC<Props> = (props) => {
               {`${errorText}`}
             </StyledInvalidText>
           ) : null}
-        </ColumnContainer>
+        </Container>
       );
 
     case EditTextInputType.ROW_BOX:
       return (
-        <RowContainer style={style}>
+        <Container style={style}>
           <StyledRowContent
             style={[
               {
@@ -456,7 +451,7 @@ const EditText: FC<Props> = (props) => {
               {errorText}
             </StyledInvalidText>
           ) : null}
-        </RowContainer>
+        </Container>
       );
   }
 };

--- a/main/__tests__/__snapshots__/EditText.test.tsx.snap
+++ b/main/__tests__/__snapshots__/EditText.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`[EditText] Type: [box] renders without crashing 1`] = `
     Array [
       Object {
         "alignSelf": "stretch",
-        "display": "flex",
         "flexDirection": "column",
       },
     ]
@@ -57,6 +56,9 @@ exports[`[EditText] Type: [box] renders without crashing 1`] = `
       style={
         Array [
           Object {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "fontSize": 15,
             "fontWeight": "500",
             "paddingBottom": 15,
@@ -80,7 +82,6 @@ exports[`[EditText] Type: [default] renders without crashing 1`] = `
     Array [
       Object {
         "alignSelf": "stretch",
-        "display": "flex",
         "flexDirection": "column",
       },
     ]
@@ -112,6 +113,9 @@ exports[`[EditText] Type: [default] renders without crashing 1`] = `
     style={
       Array [
         Object {
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
           "fontSize": 15,
           "fontWeight": "500",
           "paddingBottom": 15,

--- a/stories/dooboo-ui/EditText.stories.tsx
+++ b/stories/dooboo-ui/EditText.stories.tsx
@@ -376,12 +376,12 @@ const BoxEditText = (): React.ReactElement => {
           <EditText
             testID="email-input-box"
             type={EditTextInputType.BOX}
-            labelTextStyle= {{
+            labelTextStyle={{
               color: '#333333',
               fontSize: 14,
               lineHeight: 24,
             }}
-            focusedLabelStyle= {{
+            focusedLabelStyle={{
               color: '#333333',
             }}
             inputContainerRadius={30}
@@ -398,7 +398,6 @@ const BoxEditText = (): React.ReactElement => {
             }}
             contentStyle={{
               paddingHorizontal: 16,
-              paddingVertical: 8,
             }}
             errorText={errorEmail}
             onSubmitEditing={onSignIn}
@@ -413,12 +412,12 @@ const BoxEditText = (): React.ReactElement => {
           <EditText
             testID="password-input-box"
             type={EditTextInputType.BOX}
-            labelTextStyle= {{
+            labelTextStyle={{
               color: '#333333',
               fontSize: 14,
               lineHeight: 24,
             }}
-            focusedLabelStyle= {{
+            focusedLabelStyle={{
               color: '#333333',
             }}
             inputContainerRadius={30}
@@ -438,7 +437,6 @@ const BoxEditText = (): React.ReactElement => {
             }}
             contentStyle={{
               paddingHorizontal: 16,
-              paddingVertical: 8,
             }}
             onSubmitEditing={onSignIn}
             borderStyle={{
@@ -450,12 +448,12 @@ const BoxEditText = (): React.ReactElement => {
           <EditText
             testID="password-input-confirm"
             type={EditTextInputType.BOX}
-            labelTextStyle= {{
+            labelTextStyle={{
               color: '#333333',
               fontSize: 14,
               lineHeight: 24,
             }}
-            focusedLabelStyle= {{
+            focusedLabelStyle={{
               color: '#333333',
             }}
             inputContainerRadius={30}
@@ -472,7 +470,6 @@ const BoxEditText = (): React.ReactElement => {
             }}
             contentStyle={{
               paddingHorizontal: 16,
-              paddingVertical: 8,
             }}
             onSubmitEditing={onSignIn}
             borderStyle={{


### PR DESCRIPTION
## Description

1. fix text input password ellipsis issue by adding flex: 1 (for type={EditTextInputType.BOX} && secureTextEntry={true})
2. stories-boxType : remove style "paddingVertical: 8" to correct broken UI in android

<img width="300" alt="Screen Shot 2020-08-09 at 12 11 56 AM" src="https://user-images.githubusercontent.com/60371244/89115564-9ebbae80-d4c4-11ea-85c1-09ec57862ca4.png"> -> <img width="300" alt="Screen Shot 2020-08-09 at 12 11 56 AM" src="https://user-images.githubusercontent.com/48555121/89713795-072ef200-d9d5-11ea-9bc0-a6c906b84807.png">

## Related Issues

fix #282 

## Tests

X

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
