### PR TITLE
[Slider]fix: invalid state setting of Slider width, pageX

### DIFF
--- a/main/Slider/Thumb.tsx
+++ b/main/Slider/Thumb.tsx
@@ -49,6 +49,7 @@ const Thumb: FC<Props> = ({
       {customThumb || (
         <StyledThumb testID={testID} style={style}>
           <Animated.View
+            testID="thumb-animated"
             style={{
               width: rippleSize,
               height: rippleSize,

--- a/main/Slider/index.tsx
+++ b/main/Slider/index.tsx
@@ -1,5 +1,5 @@
 import { Animated, Easing, PanResponder, Platform, StyleProp, TextStyle, ViewStyle } from 'react-native';
-import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 import {
   getNearestPercentByValue,
   getPercentByPositionX,
@@ -68,7 +68,7 @@ const Slider: FC<Props> = ({
   labelTextStyle,
   onChange,
 }) => {
-  const sliderRef = useRef<any>();
+  const sliderRef = React.useRef<any>();
   const [sliderWidth, setSliderWidth] = useState<number>(0);
   const [sliderPositionX, setSliderPositionX] = useState(0);
   const [percent, setPercent] = useState(

--- a/main/Slider/index.tsx
+++ b/main/Slider/index.tsx
@@ -158,18 +158,18 @@ const Slider: FC<Props> = ({
       }),
     [sliderPositionX, sliderWidth, onChange],
   );
+
+  if (sliderRef.current) {
+    sliderRef.current.measure((x, y, width, height, pageX) => {
+      setSliderPositionX(pageX);
+      setSliderWidth(width);
+    });
+  }
+
   return (
     <Container
       ref={sliderRef}
       {...panResponder.panHandlers}
-      onLayout={(): void => {
-        if (sliderRef) {
-          sliderRef.current.measure((x, y, width, height, pageX) => {
-            setSliderPositionX(pageX);
-            setSliderWidth(width);
-          });
-        }
-      }}
     >
       <Rail testID="rail-test-id" style={railStyle}/>
       <Track testID="track-test-id" percent={percent} style={trackStyle}/>

--- a/main/__tests__/Slider.test.tsx
+++ b/main/__tests__/Slider.test.tsx
@@ -1,4 +1,4 @@
-import { Animated, PanResponderCallbacks, PanResponderInstance, View } from 'react-native';
+import { Animated, MeasureOnSuccessCallback, PanResponderCallbacks, PanResponderInstance, View } from 'react-native';
 import React, { useRef } from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 import {
@@ -82,6 +82,25 @@ describe('[Slider] render', () => {
       );
       expect(useRefSpy).toBeCalledTimes(1);
       expect(measure).toBeCalledTimes(1);
+    });
+
+    it('Should have slider position updated if measure callback called', () => {
+      const mockRef : { current: any, callback: MeasureOnSuccessCallback | null } = {
+        current: {
+          measure: (callback: MeasureOnSuccessCallback): void => {
+            mockRef.callback = callback;
+          },
+        },
+        callback: null,
+      };
+      jest.spyOn(React, 'useRef').mockReturnValueOnce(mockRef);
+      render(
+        <Slider />,
+      );
+      jest.spyOn(React, 'useRef').mockReturnValueOnce(mockRef);
+      act(() => {
+        mockRef.callback(0, 0, 100, 100, 0, 0);
+      });
     });
   });
 

--- a/main/__tests__/Slider.test.tsx
+++ b/main/__tests__/Slider.test.tsx
@@ -1,4 +1,4 @@
-import { Animated, View } from 'react-native';
+import { Animated, PanResponderCallbacks, PanResponderInstance, View } from 'react-native';
 import React, { useRef } from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 import {
@@ -16,6 +16,7 @@ import Rail from '../Slider/Rail';
 import { Slider } from '../../main';
 import Thumb from '../Slider/Thumb';
 import Track from '../Slider/Track';
+import { act } from 'react-test-renderer';
 
 const TEST_ID = {
   RAIL: 'rail-test-id',
@@ -24,7 +25,23 @@ const TEST_ID = {
   THUMB: 'thumb-test-id',
   LABEL: 'label-test-id',
   THUMBPOSITIONER: 'thumb-positioner-test-id',
+  THUMB_ANIMATED: 'thumb-animated',
 };
+
+let testResponder: PanResponderCallbacks = null;
+
+jest.mock('react-native/Libraries/Interaction/PanResponder', () => {
+  return {
+    create: (responder: PanResponderCallbacks): PanResponderInstance => {
+      testResponder = responder;
+      return {
+        panHandlers: {
+
+        },
+      };
+    },
+  };
+});
 
 describe('[Slider] render', () => {
   it('renders without crashing', () => {
@@ -157,6 +174,48 @@ describe('[Slider] render', () => {
     const marks = queryByTestId(TEST_ID.MARKS);
 
     expect(marks).toBeNull();
+  });
+
+  it('should respond to the touch and move of the user.', () => {
+    const rendered = render(
+      <Slider
+        onChange={(): void => {}}
+      />,
+    );
+    const thumb = rendered.getByTestId(TEST_ID.THUMB_ANIMATED);
+    jest.useFakeTimers();
+    expect(thumb.props.style.transform[0].scale).toEqual(0.01);
+    rendered.rerender(
+      <Slider
+        hideLabel={false}
+        autoLabel
+        onChange={(): void => {}}
+      />,
+    );
+    act(
+      () => {
+        if (testResponder && testResponder.onStartShouldSetPanResponder(null, null)) {
+          testResponder.onPanResponderGrant(null, null);
+        }
+      },
+    );
+    jest.runAllTimers();
+    expect(thumb.props.style.transform[0].scale).toEqual(1);
+    act(
+      () => {
+        if (
+          testResponder &&
+          testResponder.onStartShouldSetPanResponder(null, null) &&
+          testResponder.onMoveShouldSetPanResponder(null, null)
+        ) {
+          testResponder.onPanResponderMove(null, { moveX: 10 });
+          testResponder.onPanResponderRelease(null, null);
+        }
+        testResponder.onPanResponderTerminationRequest(null, null);
+      },
+    );
+    jest.runAllTimers();
+    expect(thumb.props.style.transform[0].scale).toEqual(0);
   });
 });
 

--- a/main/__tests__/Slider.test.tsx
+++ b/main/__tests__/Slider.test.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react';
-
 import { Animated, View } from 'react-native';
+import React, { useRef } from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 import {
   getNearestPercentByValue,
@@ -41,6 +40,18 @@ describe('[Slider] render', () => {
     ).asJSON();
     expect(rendered).toMatchSnapshot();
     expect(rendered).toBeTruthy();
+  });
+
+  describe('[Slider] slider.current.measure', () => {
+    it('Should have slider.current.measure called', () => {
+      const measure = jest.fn();
+      const useRefSpy = jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: { measure } });
+      render(
+        <Slider />,
+      );
+      expect(useRefSpy).toHaveBeenCalled();
+      expect(measure).toHaveBeenCalled();
+    });
   });
 
   describe('required components', () => {

--- a/main/__tests__/Slider.test.tsx
+++ b/main/__tests__/Slider.test.tsx
@@ -43,14 +43,28 @@ describe('[Slider] render', () => {
   });
 
   describe('[Slider] slider.current.measure', () => {
-    it('Should have slider.current.measure called', () => {
-      const measure = jest.fn();
+    const measure = jest.fn();
+    beforeEach(() => {
+      jest.restoreAllMocks();
+      jest.resetAllMocks();
+    });
+
+    it('Should not have slider.current.measure called when current does not exist', () => {
+      const useRefSpy = jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: null });
+      render(
+        <Slider />,
+      );
+      expect(useRefSpy).toBeCalledTimes(1);
+      expect(measure).not.toBeCalled();
+    });
+
+    it('Should have slider.current.measure called when current exist', () => {
       const useRefSpy = jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: { measure } });
       render(
         <Slider />,
       );
-      expect(useRefSpy).toHaveBeenCalled();
-      expect(measure).toHaveBeenCalled();
+      expect(useRefSpy).toBeCalledTimes(1);
+      expect(measure).toBeCalledTimes(1);
     });
   });
 

--- a/main/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/main/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -791,6 +791,7 @@ exports[`[Slider] render renders without crashing 1`] = `
               "width": 24,
             }
           }
+          testID="thumb-animated"
         />
       </View>
     </View>
@@ -859,6 +860,7 @@ exports[`[Track] [Thumb] renders without crashing 1`] = `
             "width": 20.8,
           }
         }
+        testID="thumb-animated"
       />
     </View>
   </View>


### PR DESCRIPTION

## Description
### issue
 In the Storybook, the Slider component did not work as follows.

![slider issue](https://user-images.githubusercontent.com/35516239/89727508-89b0c380-da60-11ea-9cb3-f9c36ca0f0cc.gif)
###  the cause of problem 

The cause of the problem is as follows.

relative path: `main/Slider/index.tsx`
![image](https://user-images.githubusercontent.com/35516239/89728852-3c861f00-da6b-11ea-9072-8dad0389de5b.png)

Logics that run when the slider component moves are as follows: 

- When the `onPanResponderMove` event occurs, the slider component obtains the `percentage` through the `getPercentByPositionX` function, and passes the obtained percentage to the `getStepByPercent` function to obtain the `step` value. The slider component moves the slide based on the calculated step value. 
- Debugging the problem, there was a problem with the parameter (`sliderPositionX`, `sliderWidth`) that was passed to the `getPercentByPositionX` function.

### When is sliderPositionX, sliderWidth set?
- `onLayout callback` 
![image](https://user-images.githubusercontent.com/35516239/89729095-49a40d80-da6d-11ea-9730-5e3cee0f9305.png)

### Why is the wrong `sliderPositionX`, `sliderWidth` set?
Despite the change in layout,`pageX` and `width` values that are passed to the parameters of the 'sliderRef.current.measure' callback are the same values as before the layout change.

- first `onLayout`
![image](https://user-images.githubusercontent.com/35516239/90308166-1acbe280-df18-11ea-8b5e-300de286f821.png)

- second `onLayout`, but valuse(`sliderPositionX`, `sliderWidth`) are same as first `onLayout` value
![image](https://user-images.githubusercontent.com/35516239/90308169-24ede100-df18-11ea-9e96-fa6eccfef94b.png)

It is written in the document that `onLayout` is executed not after the layout has been changed but just before the change. (https://reactnative.dev/docs/view#onlayout)
> Invoked on mount and layout changes with:
This event is fired immediately once the layout has been calculated, but the new layout > may not yet be reflected on the screen at the time the event is received, especially if a > layout animation is in progress.

### What i Do to fix bug
 So i changed when to measure and set state Slider Container width and pageX value.
* before: `onLayout` callback -> after: every render
### Result 
![success](https://user-images.githubusercontent.com/35516239/90309096-1e636780-df20-11ea-979f-9b34ef97ba3f.gif)



## Related Issues
- x

## Tests
- x 

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
