### PR TITLE
Change the margin-top in the Snackbar.stories.tsx

### DIFF
--- a/stories/packages/Snackbar.stories.tsx
+++ b/stories/packages/Snackbar.stories.tsx
@@ -18,7 +18,7 @@ const Container = styled.View`
   align-items: center;
   justify-content: center;
   flex: 1;
-  margin-top: 28;
+  margin-top: 150;
   flex-direction: column;
 `;
 


### PR DESCRIPTION
## Description
Before:
![image](https://user-images.githubusercontent.com/38123162/90800784-148e9980-e350-11ea-9b42-7aca09f21245.png)
After:
![image](https://user-images.githubusercontent.com/38123162/90803090-30e00580-e353-11ea-9409-a8b12b8e26c4.png)
Because margin-top is not enough, It couldn't be showed on the top. 
## Related Issues



## Tests

I added the following tests:


## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
