### PR TITLE
fix: outline style glitch when checkbox is checked on web

### DIFF
--- a/main/Checkbox/Checkbox.tsx
+++ b/main/Checkbox/Checkbox.tsx
@@ -1,4 +1,11 @@
-import React, { FC, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import React, {
+  FC,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { GroupCheckboxContext } from './CheckboxGroup';
 import { TouchableHighlight } from 'react-native';
 import styled from 'styled-components/native';
@@ -20,10 +27,10 @@ export interface CheckboxProps {
   id?: string;
   label: string | number;
   value?: string | number | boolean;
-  checked?: boolean
+  checked?: boolean;
   defaultChecked?: boolean;
   indeterminate?: boolean;
-  disabled?: boolean
+  disabled?: boolean;
   onChange?: (event: OnChangeEvent) => void;
   customStyle?: CustomStyle;
 }
@@ -37,7 +44,6 @@ const Checkbox: FC<CheckboxProps> = ({
   disabled = false,
   onChange,
   customStyle,
-
 }) => {
   const groupCheckboxContext = useContext(GroupCheckboxContext);
   const isMounted = useRef(false);
@@ -78,24 +84,22 @@ const Checkbox: FC<CheckboxProps> = ({
       <Container labelLeft={customStyle?.labelLeft}>
         <MarkerContainer
           boxSize={customStyle?.boxSize}
-          boxColor={disabled ? COLOR.LIGHTGRAY : customStyle?.boxColor}
-        >
+          boxColor={disabled ? COLOR.LIGHTGRAY : customStyle?.boxColor}>
           <Marker isChecked={isChecked}>
-            {!indeterminate && isChecked && <MarkerImg
-              source={{ uri: checkboxImg }}
-            />}
-            {
-              indeterminate && <Markerindeterminate
+            {!indeterminate && isChecked && (
+              <MarkerImg source={{ uri: checkboxImg }} />
+            )}
+            {indeterminate && (
+              <MarkerIndeterminate
                 boxColor={disabled ? COLOR.LIGHTGRAY : customStyle?.boxColor}
               />
-            }
+            )}
           </Marker>
         </MarkerContainer>
         <Label
           labelColor={labelColor}
           labelSize={customStyle?.labelSize}
-          labelLeft={customStyle?.labelLeft}
-        >
+          labelLeft={customStyle?.labelLeft}>
           {label}
         </Label>
       </Container>
@@ -108,8 +112,8 @@ interface ContainerProps {
 }
 
 interface MarkerContainerProps {
-  boxSize?: number
-  boxColor?: string
+  boxSize?: number;
+  boxColor?: string;
 }
 
 interface LabelProps {
@@ -120,11 +124,11 @@ interface LabelProps {
 }
 
 interface MarkerProps {
-  isChecked: boolean
+  isChecked: boolean;
 }
 
-interface MarkerindeterminateProps {
-  boxColor?: string
+interface MarkerIndeterminateProps {
+  boxColor?: string;
 }
 
 const COLOR: {
@@ -137,15 +141,16 @@ const COLOR: {
 };
 
 const Container = styled.View<ContainerProps>`
-  flex-direction: ${({ labelLeft }): string => labelLeft ? 'row-reverse' : 'row'};
+  flex-direction: ${({ labelLeft }): string =>
+    labelLeft ? 'row-reverse' : 'row'};
   justify-content: center;
   align-items: center;
 `;
 
 const MarkerContainer = styled.View<MarkerContainerProps>`
-  padding: 1.5px;
-  width: ${({ boxSize }):number => boxSize || 20}px;
-  height: ${({ boxSize }):number => boxSize || 20}px;
+  padding: 1px;
+  width: ${({ boxSize }): number => boxSize || 20}px;
+  height: ${({ boxSize }): number => boxSize || 20}px;
   background-color: ${({ boxColor }): string => boxColor || COLOR.BLUE_SKY};
 `;
 
@@ -153,7 +158,8 @@ const Marker = styled.View<MarkerProps>`
   flex: 1;
   justify-content: center;
   align-items: center;
-  background-color: ${({ isChecked }): string => isChecked ? 'transparent' : '#ffffff'};
+  background-color: ${({ isChecked }): string =>
+    isChecked ? 'transparent' : '#ffffff'};
 `;
 
 const MarkerImg = styled.Image`
@@ -163,7 +169,7 @@ const MarkerImg = styled.Image`
   resize-mode: contain;
 `;
 
-const Markerindeterminate = styled.View<MarkerindeterminateProps>`
+const MarkerIndeterminate = styled.View<MarkerIndeterminateProps>`
   width: 55%;
   height: 55%;
   background-color: ${({ boxColor }): string => boxColor || COLOR.BLUE_SKY};
@@ -171,8 +177,8 @@ const Markerindeterminate = styled.View<MarkerindeterminateProps>`
 
 const Label = styled.Text<LabelProps>`
   font-size: 20px;
-  padding-left:  ${({ labelLeft }): number => labelLeft ? 0 : 10}px;
-  padding-right: ${({ labelLeft }): number => labelLeft ? 10 : 0}px;
+  padding-left: ${({ labelLeft }): number => (labelLeft ? 0 : 10)}px;
+  padding-right: ${({ labelLeft }): number => (labelLeft ? 10 : 0)}px;
   color: ${({ labelColor }): string => labelColor || COLOR.BLACK};
 `;
 

--- a/main/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/main/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -30,10 +30,10 @@ exports[`[Checkbox] [Checkbox] Interaction should simulate props 1`] = `
           Object {
             "backgroundColor": "#E0E0E0",
             "height": 20,
-            "paddingBottom": 1.5,
-            "paddingLeft": 1.5,
-            "paddingRight": 1.5,
-            "paddingTop": 1.5,
+            "paddingBottom": 1,
+            "paddingLeft": 1,
+            "paddingRight": 1,
+            "paddingTop": 1,
             "width": 20,
           },
         ]
@@ -101,10 +101,10 @@ exports[`[Checkbox] [Checkbox] Interaction should simulate props 2`] = `
           Object {
             "backgroundColor": "#1890FF",
             "height": 20,
-            "paddingBottom": 1.5,
-            "paddingLeft": 1.5,
-            "paddingRight": 1.5,
-            "paddingTop": 1.5,
+            "paddingBottom": 1,
+            "paddingLeft": 1,
+            "paddingRight": 1,
+            "paddingTop": 1,
             "width": 20,
           },
         ]
@@ -172,10 +172,10 @@ exports[`[Checkbox] [Checkbox] Interaction should simulate props 3`] = `
           Object {
             "backgroundColor": "#FF0000",
             "height": 20,
-            "paddingBottom": 1.5,
-            "paddingLeft": 1.5,
-            "paddingRight": 1.5,
-            "paddingTop": 1.5,
+            "paddingBottom": 1,
+            "paddingLeft": 1,
+            "paddingRight": 1,
+            "paddingTop": 1,
             "width": 20,
           },
         ]
@@ -260,10 +260,10 @@ exports[`[Checkbox] [Checkbox] Interaction should simulate props 4`] = `
           Object {
             "backgroundColor": "#1890FF",
             "height": 20,
-            "paddingBottom": 1.5,
-            "paddingLeft": 1.5,
-            "paddingRight": 1.5,
-            "paddingTop": 1.5,
+            "paddingBottom": 1,
+            "paddingLeft": 1,
+            "paddingRight": 1,
+            "paddingTop": 1,
             "width": 20,
           },
         ]
@@ -342,10 +342,10 @@ exports[`[Checkbox] render without crashing 1`] = `
           Object {
             "backgroundColor": "#1890FF",
             "height": 20,
-            "paddingBottom": 1.5,
-            "paddingLeft": 1.5,
-            "paddingRight": 1.5,
-            "paddingTop": 1.5,
+            "paddingBottom": 1,
+            "paddingLeft": 1,
+            "paddingRight": 1,
+            "paddingTop": 1,
             "width": 20,
           },
         ]
@@ -439,10 +439,10 @@ exports[`[CheckboxGroup] render test should render checkall when values is not u
                 Object {
                   "backgroundColor": "#E0E0E0",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -527,10 +527,10 @@ exports[`[CheckboxGroup] render test should render checkall when values is not u
                 Object {
                   "backgroundColor": "#E0E0E0",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -597,10 +597,10 @@ exports[`[CheckboxGroup] render test should render checkall when values is not u
                 Object {
                   "backgroundColor": "#E0E0E0",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -685,10 +685,10 @@ exports[`[CheckboxGroup] render test should render checkall when values is not u
                 Object {
                   "backgroundColor": "#E0E0E0",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -787,10 +787,10 @@ exports[`[CheckboxGroup] render test should render customStyle in Options 1`] = 
                 Object {
                   "backgroundColor": "#1890FF",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -855,10 +855,10 @@ exports[`[CheckboxGroup] render test should render customStyle in Options 1`] = 
                 Object {
                   "backgroundColor": "#1890FF",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -923,10 +923,10 @@ exports[`[CheckboxGroup] render test should render customStyle in Options 1`] = 
                 Object {
                   "backgroundColor": "#1890FF",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -991,10 +991,10 @@ exports[`[CheckboxGroup] render test should render customStyle in Options 1`] = 
                 Object {
                   "backgroundColor": "#1890FF",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -1092,10 +1092,10 @@ exports[`[CheckboxGroup] render test should render disabled in Options 1`] = `
                 Object {
                   "backgroundColor": "#1890FF",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -1160,10 +1160,10 @@ exports[`[CheckboxGroup] render test should render disabled in Options 1`] = `
                 Object {
                   "backgroundColor": "#1890FF",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -1228,10 +1228,10 @@ exports[`[CheckboxGroup] render test should render disabled in Options 1`] = `
                 Object {
                   "backgroundColor": "#1890FF",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -1296,10 +1296,10 @@ exports[`[CheckboxGroup] render test should render disabled in Options 1`] = `
                 Object {
                   "backgroundColor": "#1890FF",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -1398,10 +1398,10 @@ exports[`[CheckboxGroup] render test should render disabled when CheckboxGroup p
                 Object {
                   "backgroundColor": "#E0E0E0",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -1468,10 +1468,10 @@ exports[`[CheckboxGroup] render test should render disabled when CheckboxGroup p
                 Object {
                   "backgroundColor": "#E0E0E0",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -1538,10 +1538,10 @@ exports[`[CheckboxGroup] render test should render disabled when CheckboxGroup p
                 Object {
                   "backgroundColor": "#E0E0E0",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -1608,10 +1608,10 @@ exports[`[CheckboxGroup] render test should render disabled when CheckboxGroup p
                 Object {
                   "backgroundColor": "#E0E0E0",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -1711,10 +1711,10 @@ exports[`[CheckboxGroup] render test should render options when CheckboxGroup pr
                 Object {
                   "backgroundColor": "#E0E0E0",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -1781,10 +1781,10 @@ exports[`[CheckboxGroup] render test should render options when CheckboxGroup pr
                 Object {
                   "backgroundColor": "#E0E0E0",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -1851,10 +1851,10 @@ exports[`[CheckboxGroup] render test should render options when CheckboxGroup pr
                 Object {
                   "backgroundColor": "#E0E0E0",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -1953,10 +1953,10 @@ exports[`[CheckboxGroup] render test should render without crashing 1`] = `
                 Object {
                   "backgroundColor": "#1890FF",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -2039,10 +2039,10 @@ exports[`[CheckboxGroup] render test should render without crashing 1`] = `
                 Object {
                   "backgroundColor": "#1890FF",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -2107,10 +2107,10 @@ exports[`[CheckboxGroup] render test should render without crashing 1`] = `
                 Object {
                   "backgroundColor": "#1890FF",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]
@@ -2193,10 +2193,10 @@ exports[`[CheckboxGroup] render test should render without crashing 1`] = `
                 Object {
                   "backgroundColor": "#1890FF",
                   "height": 20,
-                  "paddingBottom": 1.5,
-                  "paddingLeft": 1.5,
-                  "paddingRight": 1.5,
-                  "paddingTop": 1.5,
+                  "paddingBottom": 1,
+                  "paddingLeft": 1,
+                  "paddingRight": 1,
+                  "paddingTop": 1,
                   "width": 20,
                 },
               ]


### PR DESCRIPTION
## Description

The bug was caused by the padding style of 'MarkerContainer' being set to 1.5 px, and I fixed it's value to 1px.

## Related Issues

#335 

## Tests

just jest test

## Checklist

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
