### PR TITLE
fix: the test parts set value to new Date() when there is no prop

### DIFF
--- a/main/DatePicker/Calendar/Calendar.tsx
+++ b/main/DatePicker/Calendar/Calendar.tsx
@@ -48,6 +48,7 @@ interface Props {
   pastRange?: number; // Number of past months displayed on the calendar
   futureRange?: number; // Number of future months displayed on the calendar
   calendarWidth: number; // calendar width
+  locale?: string;
   titleContent?: (monthFirst: Date) => React.ReactElement;
   weekdayFormat?: 'narrow' | 'short';
 }
@@ -134,6 +135,7 @@ function Calendar(props: Props): React.ReactElement {
           width: props.calendarWidth,
           height: 22,
         }}
+        locale={props.locale}
         weekdayFormat={props.weekdayFormat}
       />
       <FlatList

--- a/main/DatePicker/Calendar/CalendarWeekDays.tsx
+++ b/main/DatePicker/Calendar/CalendarWeekDays.tsx
@@ -28,6 +28,7 @@ const DayTitle = styled.Text`
 interface Props {
   style?: ViewStyle;
   calendarWidth: number;
+  locale?: string;
   weekdayFormat?: 'narrow' | 'short';
 }
 
@@ -39,7 +40,7 @@ function CalendarWeekDays(props: Props): React.ReactElement {
 
   for (let idx = 0; idx <= 6; idx++) {
     const matchMonth = new Date(2020, 8, 6 + idx);
-    const weekDay = matchMonth.toLocaleString('default', {
+    const weekDay = matchMonth.toLocaleString(props.locale, {
       weekday: props.weekdayFormat || 'narrow', // 'narrow',
     });
 

--- a/main/DatePicker/PickerCalendar.tsx
+++ b/main/DatePicker/PickerCalendar.tsx
@@ -28,6 +28,7 @@ interface Props {
   selectedDate?: Date;
   onSelectDate: (date: Date) => void;
   containerStyle?: ViewStyle;
+  locale?: string;
   onBackdropPress?: () => void;
   calendarWidth?: number;
   weekdayFormat?: 'narrow' | 'short';
@@ -36,7 +37,7 @@ interface Props {
 }
 
 const PickerCalendar: FC<Props> = (props) => {
-  const { calendarWidth = 300 } = props;
+  const { calendarWidth = 300, locale = 'default' } = props;
 
   return (
     <Modal visible={props.visible} transparent={true} animationType={'fade'}>
@@ -70,6 +71,7 @@ const PickerCalendar: FC<Props> = (props) => {
                 containerStyle={{
                   overflow: 'hidden',
                 }}
+                locale={locale}
                 renderDay={({
                   date,
                   isCurrentMonth,

--- a/main/DatePicker/README.md
+++ b/main/DatePicker/README.md
@@ -16,6 +16,7 @@
 | style                |           | ViewStyle                                     |                                        |
 | label                |           | string                                        | `default arrow image`                  |
 | labelTextStyle       |           | TextStyle                                     | ``                                     |
+| locale               |           | string                                        | `default`                              |
 | errorText            |           | string                                        | `Invalid Date`                         |
 | errorTextStyle       |           | TextStyle                                     | `{ color: '#F00', textAlign: 'left' }` |
 | dateTextStyle        |           | TextStyle                                     |

--- a/main/DatePicker/index.tsx
+++ b/main/DatePicker/index.tsx
@@ -17,6 +17,7 @@ interface Props {
   style?: ViewStyle;
   label?: string;
   labelTextStyle?: TextStyle;
+  locale?: string;
   errorText?: string;
   errorTextStyle?: TextStyle;
   dateTextStyle?: TextStyle;
@@ -59,6 +60,7 @@ const DatePicker = (props: Props): React.ReactElement => {
           setCalendarVisible(false);
         }}
         containerStyle={{ width: 300, height: 350 }}
+        locale={props.locale}
         weekdayFormat={props.weekdayFormat}
         titleContent={props.titleContent}
       />

--- a/main/__tests__/DatePicker.test.tsx
+++ b/main/__tests__/DatePicker.test.tsx
@@ -15,11 +15,11 @@ import { TouchableOpacity } from 'react-native';
 import { render } from '@testing-library/react-native';
 import renderer from 'react-test-renderer';
 
-const standardDate = new Date('2020-09-01');
+const standardDate = new Date('2020-09-13');
 
 describe('[DatePicker] render', () => {
   it('should render without crashing', () => {
-    const rendered = render(<DatePicker />).asJSON();
+    const rendered = render(<DatePicker selectedDate={standardDate} />).asJSON();
 
     // expect(rendered).toMatchSnapshot();
     expect(rendered).toBeTruthy();
@@ -29,7 +29,7 @@ describe('[DatePicker] render', () => {
 describe('[DateInput] render', () => {
   it('should render without crashing', () => {
     const rendered = render(
-      <DateInput onPressCalendar={(): void => {}} />,
+      <DateInput onPressCalendar={(): void => {}} selectedDate={standardDate} />,
     ).asJSON();
 
     // expect(rendered).toMatchSnapshot();
@@ -39,7 +39,7 @@ describe('[DateInput] render', () => {
     it('should simulate onPress', () => {
       const onPressCalendar = jest.fn();
       const rendered = renderer.create(
-        <DateInput onPressCalendar={onPressCalendar} />,
+        <DateInput onPressCalendar={onPressCalendar} selectedDate={standardDate} />,
         {
           createNodeMock: () => {
             return {
@@ -63,7 +63,11 @@ describe('[DateInput] render', () => {
 describe('[PickerCalendar] render', () => {
   it('should render without crashing', () => {
     const rendered = render(
-      <PickerCalendar visible={false} onSelectDate={(): void => {}} />,
+      <PickerCalendar
+        visible={false}
+        onSelectDate={(): void => {}}
+        selectedDate={standardDate}
+        weekdayFormat={'narrow'} />,
     ).asJSON();
 
     // expect(rendered).toMatchSnapshot();
@@ -75,8 +79,9 @@ describe('[Calendar]', () => {
   it('should render without crashing', () => {
     const rendered = render(
       <Calendar
+        initDate={standardDate}
+        renderDay={() => <CalendarDate date={standardDate} isToday={false} />}
         calendarWidth={300}
-        renderDay={() => <CalendarDate date={standardDate}></CalendarDate>}
       />,
     ).asJSON();
 
@@ -88,7 +93,7 @@ describe('[Calendar]', () => {
 describe('[CalendarDate] render', () => {
   it('should render without crashing', () => {
     const rendered = render(
-      <CalendarDate onPress={(): void => {}} date={standardDate} />,
+      <CalendarDate onPress={(): void => {}} date={standardDate} isToday={false} />,
     ).asJSON();
 
     // expect(rendered).toMatchSnapshot();
@@ -99,7 +104,7 @@ describe('[CalendarDate] render', () => {
     it('should simulate onPress', () => {
       const onSelectDate = jest.fn();
       const rendered = renderer.create(
-        <CalendarDate onPress={onSelectDate} date={standardDate} />,
+        <CalendarDate onPress={onSelectDate} date={standardDate} isToday={false} />,
         {
           createNodeMock: () => {
             return {
@@ -126,8 +131,8 @@ describe('[CalendarMonth] render', () => {
       <CalendarMonth
         monthDate={standardDate}
         calendarWidth={300}
-        renderDay={() => <CalendarDate date={standardDate}></CalendarDate>}
-        today={new Date(standardDate)}
+        renderDay={() => <CalendarDate date={standardDate} isToday={false} />}
+        today={standardDate}
       />,
     ).asJSON();
 

--- a/main/__tests__/DatePicker.test.tsx
+++ b/main/__tests__/DatePicker.test.tsx
@@ -19,7 +19,7 @@ const standardDate = new Date('2020-09-13');
 
 describe('[DatePicker] render', () => {
   it('should render without crashing', () => {
-    const rendered = render(<DatePicker selectedDate={standardDate} />).asJSON();
+    const rendered = render(<DatePicker selectedDate={standardDate} locale={'en'} />).asJSON();
 
     // expect(rendered).toMatchSnapshot();
     expect(rendered).toBeTruthy();
@@ -67,6 +67,7 @@ describe('[PickerCalendar] render', () => {
         visible={false}
         onSelectDate={(): void => {}}
         selectedDate={standardDate}
+        locale={'en'}
         weekdayFormat={'narrow'} />,
     ).asJSON();
 
@@ -82,6 +83,7 @@ describe('[Calendar]', () => {
         initDate={standardDate}
         renderDay={() => <CalendarDate date={standardDate} isToday={false} />}
         calendarWidth={300}
+        locale={'en'}
       />,
     ).asJSON();
 
@@ -144,7 +146,7 @@ describe('[CalendarMonth] render', () => {
 describe('[CalendarWeekDays] render', () => {
   it('should render without crashing', () => {
     const rendered = render(
-      <CalendarWeekDays calendarWidth={300} weekdayFormat={'narrow'} />,
+      <CalendarWeekDays calendarWidth={300} weekdayFormat={'narrow'} locale={'en'} />,
     ).asJSON();
 
     // expect(rendered).toMatchSnapshot();


### PR DESCRIPTION
## Description

I thought I fixed all of the new Date operator related DatePicker test issue. #340
However, there are some parts of set value to new Date when there is no prop.
So, I modified them.

## Related Issues

#337 

## Tests

jest

## Checklist

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
