### PR TITLE
feat(rating): new customItem and containerStyle properties[Rating]

### DIFF
--- a/main/Rating/README.md
+++ b/main/Rating/README.md
@@ -3,16 +3,35 @@
 > Simple rating component for react-native. This component supports 'rating' with several options like changing with total number, read-only and disabled option.
 
 ## Preview
+
 ![rating-ios-test-image](https://user-images.githubusercontent.com/37579661/89115320-22c06700-d4c2-11ea-80e5-614738500184.png)
-  
+
 ## Props
 
-| Property | Required | Types   | Default  | Description                                                                                   |
-| -------- | -------- | ------- | -------- | --------------------------------------------------------------------------------------------- |
-| total    | ✓        | number  |          | set the total rating value                                                                    |
-| value    | ✓        | number  |          | set the rating value that will show on the screen. (The value will automatically round down.) |
-| onChange |          | func    | () => {} | set the handler to handle change event                                                        |
-| disabled |          | boolean | false    | disabled state of rating                                                                      |
+| Property       | Required | Types      | Default  | Description                                                                                   |
+| -------------- | -------- | ---------- | -------- | --------------------------------------------------------------------------------------------- |
+| total          | ✓        | number     |          | set the total rating value                                                                    |
+| value          | ✓        | number     |          | set the rating value that will show on the screen. (The value will automatically round down.) |
+| onChange       |          | func       | () => {} | set the handler to handle change event                                                        |
+| disabled       |          | boolean    | false    | disabled state of rating                                                                      |
+| customItem     |          | CustomItem |          | set the custom components for rating item instead of default star image                       |
+| containerStyle |          | ViewStyle  |          | set the user style the Content component.                                                     |
+
+```ts
+interface CustomItem {
+  onComponent: React.ReactElement;
+  offComponent: React.ReactElement;
+}
+
+/** Default container style */
+const ContainerWrapper = styled.View<Props>`
+  width: ${({ total }): number => total * 30}px;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  opacity: ${({ disabled }): number => (disabled ? 0.5 : 1)};
+`;
+```
 
 ## Installation
 

--- a/main/Rating/index.tsx
+++ b/main/Rating/index.tsx
@@ -2,12 +2,16 @@ import React, { useMemo } from 'react';
 import { StyleProp, ViewStyle } from 'react-native';
 import styled from 'styled-components/native';
 
+interface CustomItem {
+  onComponent: React.ReactElement;
+  offComponent: React.ReactElement;
+}
 interface Props {
   total: number;
   value: number;
   onChange?: (value: number) => void;
   disabled?: boolean;
-  customItem?: CustomStar;
+  customItem?: CustomItem;
   containerStyle?: StyleProp<ViewStyle>;
 }
 
@@ -22,11 +26,6 @@ interface StarProps {
   onPress: () => void;
   disabled?: boolean;
   customItem?: CustomItem;
-}
-
-interface CustomItem {
-  onComponent: React.ReactElement;
-  offComponent: React.ReactElement;
 }
 
 const ContainerWrapper = styled.View<ContainerWrapperProps>`

--- a/main/Rating/index.tsx
+++ b/main/Rating/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-
+import { StyleProp, ViewStyle } from 'react-native';
 import styled from 'styled-components/native';
 
 interface Props {
@@ -7,6 +7,8 @@ interface Props {
   value: number;
   onChange?: (value: number) => void;
   disabled?: boolean;
+  customItem?: CustomStar;
+  containerStyle?: StyleProp<ViewStyle>;
 }
 
 interface ContainerWrapperProps {
@@ -16,42 +18,53 @@ interface ContainerWrapperProps {
 
 interface StarProps {
   key: number;
-  on: boolean;
+  isOn: boolean;
   onPress: () => void;
   disabled?: boolean;
+  customItem?: CustomItem;
+}
+
+interface CustomItem {
+  onComponent: React.ReactElement;
+  offComponent: React.ReactElement;
 }
 
 const ContainerWrapper = styled.View<ContainerWrapperProps>`
   width: ${({ total }): number => total * 30}px;
-  height: 30px;
   flex-direction: row;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
   opacity: ${({ disabled }): number => (disabled ? 0.5 : 1)};
 `;
 
 const StarWrapper = styled.TouchableOpacity`
-  width: 30px;
-  height: 100%;
 `;
 
 const StyledImage = styled.Image`
-  width: 100%;
-  height: 100%;
+  width: 30px;
+  height: 30px;
 `;
 
-function StarComponent(props: StarProps): React.ReactElement {
+function StarComponent({ customItem, onPress, isOn, disabled }: StarProps): React.ReactElement {
   const handlePress = (): void => {
-    props.onPress();
+    onPress();
   };
 
-  const image = props.on
-    ? require('../__assets__/star_s.png')
-    : require('../__assets__/star_d.png');
+  const star: React.ReactElement = React.useMemo(() => {
+    if (customItem) {
+      return isOn ? customItem.onComponent : customItem.offComponent;
+    } else {
+      const image = isOn
+        ? require('../__assets__/star_s.png')
+        : require('../__assets__/star_d.png');
+
+      return <StyledImage source={image} resizeMode="contain" />;
+    }
+  }, [customItem?.onComponent, customItem?.offComponent, isOn]);
 
   return (
-    <StarWrapper onPress={handlePress} activeOpacity={props.disabled ? 1 : 0.7}>
-      <StyledImage source={image} resizeMode="contain" />
+    <StarWrapper onPress={handlePress} activeOpacity={disabled ? 1 : 0.7}>
+      {star}
     </StarWrapper>
   );
 }
@@ -69,17 +82,18 @@ function Rating(props: Props): React.ReactElement {
     return initArr.map((item, index) => (
       <StarComponent
         key={index}
-        on={props.value - 1 >= index}
+        isOn={props.value - 1 >= index}
         onPress={(): void => {
           (props.onChange && !props.disabled) && _handlePress(index);
         }}
         disabled={!props.onChange || props.disabled}
+        customItem={props.customItem}
       />
     ));
   }, [props.value, props.onChange, props.disabled]);
 
   return (
-    <ContainerWrapper total={props.total} disabled={props.disabled}>
+    <ContainerWrapper style={props.containerStyle} total={props.total} disabled={props.disabled}>
       {starsArr}
     </ContainerWrapper>
   );

--- a/main/__tests__/Rating.test.tsx
+++ b/main/__tests__/Rating.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Rating } from '../../main';
 // Note: test renderer must be required after react-native.
-import { TouchableOpacity } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
+import { Rating } from '../../main';
 import renderer from 'react-test-renderer';
 
 const defaultProps = {
@@ -62,6 +62,30 @@ describe('[Rating] render', () => {
       );
 
       rendered.update(component({ value: 1 }));
+      expect(rendered).toMatchSnapshot();
+      expect(rendered).toBeTruthy();
+
+      rendered.update(component({ disabled: true }));
+      expect(rendered).toMatchSnapshot();
+      expect(rendered).toBeTruthy();
+    });
+
+    it('should simulate customItem and containerStyle props', (): void => {
+      const rendered = renderer.create(
+        component({
+          ...defaultProps,
+          customItem: {
+            onComponent: <View />,
+            offComponent: <View />,
+          },
+          containerStyle: {
+            width: 300,
+          },
+          testID: 'RATING_ID',
+        }),
+      );
+
+      rendered.update(component({ value: 3 }));
       expect(rendered).toMatchSnapshot();
       expect(rendered).toBeTruthy();
 

--- a/main/__tests__/__snapshots__/Rating.test.tsx.snap
+++ b/main/__tests__/__snapshots__/Rating.test.tsx.snap
@@ -1,14 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`[Rating] render [Rating] Interaction should simulate props 1`] = `
+exports[`[Rating] render [Rating] Interaction should simulate customItem and containerStyle props 1`] = `
 <View
   style={
     Array [
       Object {
         "alignItems": "center",
         "flexDirection": "row",
-        "height": 30,
-        "justifyContent": "center",
+        "justifyContent": "space-between",
         "opacity": 1,
         "width": "NaNpx",
       },
@@ -27,9 +26,7 @@ exports[`[Rating] render [Rating] Interaction should simulate props 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Object {
-        "height": "100%",
         "opacity": 1,
-        "width": 30,
       }
     }
   >
@@ -43,8 +40,8 @@ exports[`[Rating] render [Rating] Interaction should simulate props 1`] = `
       style={
         Array [
           Object {
-            "height": "100%",
-            "width": "100%",
+            "height": 30,
+            "width": 30,
           },
         ]
       }
@@ -53,7 +50,7 @@ exports[`[Rating] render [Rating] Interaction should simulate props 1`] = `
 </View>
 `;
 
-exports[`[Rating] render [Rating] Interaction should simulate props 2`] = `
+exports[`[Rating] render [Rating] Interaction should simulate customItem and containerStyle props 2`] = `
 <View
   disabled={true}
   style={
@@ -61,8 +58,7 @@ exports[`[Rating] render [Rating] Interaction should simulate props 2`] = `
       Object {
         "alignItems": "center",
         "flexDirection": "row",
-        "height": 30,
-        "justifyContent": "center",
+        "justifyContent": "space-between",
         "opacity": 0.5,
         "width": "NaNpx",
       },
@@ -81,9 +77,7 @@ exports[`[Rating] render [Rating] Interaction should simulate props 2`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Object {
-        "height": "100%",
         "opacity": 1,
-        "width": 30,
       }
     }
   >
@@ -97,8 +91,109 @@ exports[`[Rating] render [Rating] Interaction should simulate props 2`] = `
       style={
         Array [
           Object {
-            "height": "100%",
-            "width": "100%",
+            "height": 30,
+            "width": 30,
+          },
+        ]
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`[Rating] render [Rating] Interaction should simulate props 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "opacity": 1,
+        "width": "NaNpx",
+      },
+    ]
+  }
+>
+  <View
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+  >
+    <Image
+      resizeMode="contain"
+      source={
+        Object {
+          "testUri": "../../../main/__assets__/star_s.png",
+        }
+      }
+      style={
+        Array [
+          Object {
+            "height": 30,
+            "width": 30,
+          },
+        ]
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`[Rating] render [Rating] Interaction should simulate props 2`] = `
+<View
+  disabled={true}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "opacity": 0.5,
+        "width": "NaNpx",
+      },
+    ]
+  }
+>
+  <View
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+  >
+    <Image
+      resizeMode="contain"
+      source={
+        Object {
+          "testUri": "../../../main/__assets__/star_d.png",
+        }
+      }
+      style={
+        Array [
+          Object {
+            "height": 30,
+            "width": 30,
           },
         ]
       }
@@ -114,8 +209,7 @@ exports[`[Rating] render renders without crashing 1`] = `
       Object {
         "alignItems": "center",
         "flexDirection": "row",
-        "height": 30,
-        "justifyContent": "center",
+        "justifyContent": "space-between",
         "opacity": 1,
         "width": 150,
       },
@@ -135,9 +229,7 @@ exports[`[Rating] render renders without crashing 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Object {
-        "height": "100%",
         "opacity": 1,
-        "width": 30,
       }
     }
   >
@@ -151,8 +243,8 @@ exports[`[Rating] render renders without crashing 1`] = `
       style={
         Array [
           Object {
-            "height": "100%",
-            "width": "100%",
+            "height": 30,
+            "width": 30,
           },
         ]
       }
@@ -170,9 +262,7 @@ exports[`[Rating] render renders without crashing 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Object {
-        "height": "100%",
         "opacity": 1,
-        "width": 30,
       }
     }
   >
@@ -186,8 +276,8 @@ exports[`[Rating] render renders without crashing 1`] = `
       style={
         Array [
           Object {
-            "height": "100%",
-            "width": "100%",
+            "height": 30,
+            "width": 30,
           },
         ]
       }
@@ -205,9 +295,7 @@ exports[`[Rating] render renders without crashing 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Object {
-        "height": "100%",
         "opacity": 1,
-        "width": 30,
       }
     }
   >
@@ -221,8 +309,8 @@ exports[`[Rating] render renders without crashing 1`] = `
       style={
         Array [
           Object {
-            "height": "100%",
-            "width": "100%",
+            "height": 30,
+            "width": 30,
           },
         ]
       }
@@ -240,9 +328,7 @@ exports[`[Rating] render renders without crashing 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Object {
-        "height": "100%",
         "opacity": 1,
-        "width": 30,
       }
     }
   >
@@ -256,8 +342,8 @@ exports[`[Rating] render renders without crashing 1`] = `
       style={
         Array [
           Object {
-            "height": "100%",
-            "width": "100%",
+            "height": 30,
+            "width": 30,
           },
         ]
       }
@@ -275,9 +361,7 @@ exports[`[Rating] render renders without crashing 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Object {
-        "height": "100%",
         "opacity": 1,
-        "width": 30,
       }
     }
   >
@@ -291,8 +375,8 @@ exports[`[Rating] render renders without crashing 1`] = `
       style={
         Array [
           Object {
-            "height": "100%",
-            "width": "100%",
+            "height": 30,
+            "width": 30,
           },
         ]
       }

--- a/stories/dooboo-ui/Rating.stories.tsx
+++ b/stories/dooboo-ui/Rating.stories.tsx
@@ -22,6 +22,20 @@ const Result = styled.Text`
   margin: 10px 0;
 `;
 
+const CustomOn = styled.View`
+  height: 30px;
+  width: 30px;
+  border-radius: 15px;
+  background-color: #888;
+`;
+
+const CustomOff = styled.View`
+  height: 30px;
+  width: 30px;
+  border-radius: 15px;
+  background-color: #000;
+`;
+
 function Default(): React.ReactElement {
   const [value, setValue] = React.useState(0);
   const disabled = boolean('disabled', false);
@@ -41,6 +55,27 @@ function Default(): React.ReactElement {
         value={value}
         onChange={handleChange}
         disabled={disabled}
+      />
+      <Rating
+        total={number('total', 5)}
+        value={value}
+        onChange={handleChange}
+        disabled={disabled}
+        customItem={{
+          onComponent: <CustomOn />,
+          offComponent: <CustomOff />,
+        }}
+      />
+      <Rating
+        total={number('total', 5)}
+        value={value}
+        onChange={handleChange}
+        disabled={disabled}
+        customItem={{
+          onComponent: <CustomOn />,
+          offComponent: <CustomOff />,
+        }}
+        containerStyle={{ width: 200 }}
       />
       <Result>Selected: {value} stars</Result>
     </Container>


### PR DESCRIPTION
## Description

User can customize rating component called `customItem` and `containerStyle` using their own component instead of default start image. 

## Related Issues

#363 

## Tests

I added the following tests:

```ts
it('should simulate customItem and containerStyle props', (): void => {
      const rendered = renderer.create(
        component({
          ...defaultProps,
          customItem: {
            onComponent: <View />,
            offComponent: <View />,
          },
          containerStyle: {
            width: 300,
          },
          testID: 'RATING_ID',
        }),
      );

      rendered.update(component({ value: 3 }));
      expect(rendered).toMatchSnapshot();
      expect(rendered).toBeTruthy();

      rendered.update(component({ disabled: true }));
      expect(rendered).toMatchSnapshot();
      expect(rendered).toBeTruthy();
});
```
Snapshot is updated by `npx jest rating -u`

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
