### PR TITLE
[PinchZoom] Fix getting relative position of the native event. 

### DIFF
--- a/packages/PinchZoom/index.tsx
+++ b/packages/PinchZoom/index.tsx
@@ -9,6 +9,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { number } from '@storybook/addon-knobs';
 
 type Props = PropsWithChildren<{
   style?: ViewStyle,
@@ -35,13 +36,18 @@ function getDistanceFromTouches(
 }
 
 function getRelativeTouchesCenterPosition(
-  touches: NativeTouchEvent[], layout: {width: number, height: number, pageX: number, pageY: number},
+  touches: NativeTouchEvent[],
+  layout: { width: number, height: number, pageX: number, pageY: number },
+  transformCache: { scale: number, translateX: number, translateY: number },
 ): TouchePosition {
+  const pageX = (touches[0].pageX + touches[1].pageX) / 2 - layout.width / 2 - layout.pageX;
+  const pageY = (touches[0].pageY + touches[1].pageY) / 2 - layout.height / 2 - layout.pageY;
+
   return {
-    locationX: (touches[0].locationX + touches[1].locationX) / 2 - layout.width / 2,
-    locationY: (touches[0].locationY + touches[1].locationY) / 2 - layout.height / 2,
-    pageX: (touches[0].pageX + touches[1].pageX) / 2 - layout.width / 2 - layout.pageX,
-    pageY: (touches[0].pageY + touches[1].pageY) / 2 - layout.height / 2 - layout.pageY,
+    locationX: (pageX - transformCache.translateX) / transformCache.scale,
+    locationY: (pageY - transformCache.translateY) / transformCache.scale,
+    pageX,
+    pageY,
   };
 }
 
@@ -57,6 +63,7 @@ function PinchZoom(props: Props, ref: Ref<PinchZoomRef>): ReactElement {
   const layout = useRef<{width: number, height: number, pageX: number, pageY: number}>();
   const decayingTranslateAnimation = useRef<Animated.CompositeAnimation>();
   const isResponderActive = useRef(false);
+  const movingVelocity = useRef<{x: number, y: number}>();
 
   containerView.current?.measure((x, y, width, height, pageX, pageY) => {
     layout.current = { width, height, pageX, pageY };
@@ -113,11 +120,17 @@ function PinchZoom(props: Props, ref: Ref<PinchZoomRef>): ReactElement {
 
         initialDistance.current = undefined;
 
-        if (touches.length === 2 && layout.current != null) {
-          initialDistance.current = getDistanceFromTouches(touches);
-          initialTouchesCenter.current = getRelativeTouchesCenterPosition(touches, layout.current);
-        } else {
-          initialDistance.current = undefined;
+        if (layout.current != null) {
+          if (touches.length === 2) {
+            initialDistance.current = getDistanceFromTouches(touches);
+            initialTouchesCenter.current = getRelativeTouchesCenterPosition(touches, layout.current, transformCache);
+          } else {
+            initialDistance.current = undefined;
+
+            initialTouchesCenter.current = getRelativeTouchesCenterPosition(
+              [touches[0], touches[0]], layout.current, transformCache,
+            );
+          }
         }
       },
       onPanResponderMove: ({ nativeEvent }, gestureState) => {
@@ -127,6 +140,15 @@ function PinchZoom(props: Props, ref: Ref<PinchZoomRef>): ReactElement {
           return;
         }
 
+        if (movingVelocity.current) {
+          movingVelocity.current = {
+            x: (movingVelocity.current.x + gestureState.vx) / 2,
+            y: (movingVelocity.current.y + gestureState.vy) / 2,
+          };
+        } else {
+          movingVelocity.current = { x: gestureState.vx, y: gestureState.vy };
+        }
+
         if (touches.length === 2) {
           if (initialDistance.current && initialTouchesCenter.current && layout.current) {
             const newScale = Math.max(
@@ -134,7 +156,7 @@ function PinchZoom(props: Props, ref: Ref<PinchZoomRef>): ReactElement {
               getDistanceFromTouches(touches) / initialDistance.current * lastTransform.current.scale,
             );
 
-            const { pageX, pageY } = getRelativeTouchesCenterPosition(touches, layout.current);
+            const { pageX, pageY } = getRelativeTouchesCenterPosition(touches, layout.current, transformCache);
 
             scale.setValue(newScale);
 
@@ -153,9 +175,13 @@ function PinchZoom(props: Props, ref: Ref<PinchZoomRef>): ReactElement {
             });
           } else {
             initialDistance.current = getDistanceFromTouches(touches);
-            initialTouchesCenter.current = getRelativeTouchesCenterPosition(touches, layout.current);
+            initialTouchesCenter.current = getRelativeTouchesCenterPosition(touches, layout.current, transformCache);
           }
         } else if (touches.length === 1) {
+          if (initialDistance.current) {
+            return;
+          }
+
           const newTranslateX = lastTransform.current.translateX + gestureState.dx;
           const newTranslateY = lastTransform.current.translateY + gestureState.dy;
 
@@ -201,7 +227,7 @@ function PinchZoom(props: Props, ref: Ref<PinchZoomRef>): ReactElement {
           decayingTranslateAnimation.current = Animated.decay(
             translate,
             {
-              velocity: { x: gestureState.vx, y: gestureState.vy },
+              velocity: movingVelocity.current ?? { x: 0, y: 0 },
               useNativeDriver: true,
             },
           );


### PR DESCRIPTION
## Description

There was some abnormal movement of pinchzoom in the android device.
I found that was because the locationX(locationY) value of the second touches is not equal to the value I expected. 
So I changed to calculate the values by pageX, pageY values of the NativeEvent. 

## Related Issues

_

## Tests

_

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
