### PR TITLE
[Button] style props patches

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1,5 +1,9 @@
 ## Changelogs
 
+## 0.0.28
+
+- Added `TouchableOpacity` style prop to [Button] [#37`](https://github.com/dooboolab/dooboo-ui/pull/371`).
+
 ## 0.0.27
 
 - Updated packages and applied new linting rules [#370](https://github.com/dooboolab/dooboo-ui/pull/370).

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dooboo-ui",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "dooboolab",

--- a/main/Button.tsx
+++ b/main/Button.tsx
@@ -1,12 +1,14 @@
 import {
   ActivityIndicator,
   LayoutRectangle,
+  StyleProp,
   StyleSheet,
   Text,
   TextProps,
   TouchableOpacity,
   TouchableOpacityProps,
   View,
+  ViewStyle,
 } from 'react-native';
 import React, { useRef, useState } from 'react';
 
@@ -55,6 +57,7 @@ interface Props {
   indicatorColor?: string;
   loading?: boolean;
   disabled?: boolean;
+  style?: StyleProp<ViewStyle>;
   styles?: StylesType;
   leftElement?: React.ReactElement;
   rightElement?: React.ReactElement;

--- a/stories/dooboo-ui/Button.stories.tsx
+++ b/stories/dooboo-ui/Button.stories.tsx
@@ -36,9 +36,9 @@ function Default(): React.ReactElement {
           loading={false}
           text="😀 😎 👍 💯"
           onPress={action('Clicked')}
+          style={{ marginVertical: 40 }}
           styles={{
             container: {
-              marginVertical: 40,
               borderWidth: 0.5,
             },
           }}
@@ -57,9 +57,9 @@ function Default(): React.ReactElement {
         />
 
         <Button
+          style={{ marginVertical: 40 }}
           styles={{
             container: {
-              marginVertical: 40,
               borderWidth: 0.5,
             },
             text: {
@@ -81,9 +81,9 @@ function Default(): React.ReactElement {
           }
           loading={googleLoading}
           indicatorColor="#023059"
+          style={{ marginVertical: 20 }}
           styles={{
             container: {
-              marginVertical: 20,
               backgroundColor: '#ccc',
             },
           }}


### PR DESCRIPTION
## Description

Altough there are more `styles` to decorate inside the `TouchableOpacity`, we did not have the `style` of its own component. Here is where you should place styles like margin.

Bump ver to `0.0.28`.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/dooboo-ui/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
